### PR TITLE
Refactor available players in HR

### DIFF
--- a/src/matching/__init__.py
+++ b/src/matching/__init__.py
@@ -3,5 +3,5 @@
 from .matching import Matching
 from .player import Player
 from .game import Game
-from .solvers import StableMarriage, HospitalResident
+from .solvers import HospitalResident, StableMarriage, StudentAllocation
 from .version import __version__

--- a/src/matching/solvers/__init__.py
+++ b/src/matching/solvers/__init__.py
@@ -2,3 +2,4 @@
 
 from .hospital_resident import HospitalResident, hospital_resident
 from .stable_marriage import StableMarriage, stable_marriage
+from .student_allocation import StudentAllocation

--- a/src/matching/solvers/hospital_resident.py
+++ b/src/matching/solvers/hospital_resident.py
@@ -215,7 +215,7 @@ def _check_resident_unhappy(resident, hospital):
 
 def _check_hospital_unhappy(resident, hospital):
     """ Determine whether a hospital is unhappy because they are
-    under-subscribed, or they prefer the resident to at least one of their 
+    under-subscribed, or they prefer the resident to at least one of their
     current matches. """
 
     return len(hospital.matching) < hospital.capacity or any(
@@ -223,7 +223,7 @@ def _check_hospital_unhappy(resident, hospital):
     )
 
 
-def hospital_resident(residents, hospitals, optimal="resident", verbose=False):
+def hospital_resident(residents, hospitals, optimal="resident"):
     """ Solve an instance of HR matching game by treating it as a stable
     marriage game with hospital capacities. A unique, stable and optimal
     matching is found for the given set of residents (residents) and hospitals
@@ -252,13 +252,13 @@ def hospital_resident(residents, hospitals, optimal="resident", verbose=False):
         of `hospitals`, and the values are their matches ranked by preference.
     """
 
-    if optimal in ["resident", "resident"]:
-        return resident_optimal(residents, hospitals, verbose)
-    if optimal in ["hospital", "hospital"]:
-        return hospital_optimal(residents, hospitals, verbose)
+    if optimal == "resident":
+        return resident_optimal(residents, hospitals)
+    if optimal == "hospital":
+        return hospital_optimal(residents, hospitals)
 
 
-def resident_optimal(residents, hospitals, verbose):
+def resident_optimal(residents, hospitals):
     """ Solve the instance of HR to be resident- (resident-) optimal. The
     algorithm (set out in `DubinsFreedman1981`_) is as follows:
 
@@ -290,22 +290,22 @@ def resident_optimal(residents, hospitals, verbose):
 
         match_pair(resident, hospital)
 
-        if len(reviewer.matching) > reviewer.capacity:
-            worst = reviewer.get_worst_match()
-            unmatch_pair(worst, reviewer)
-            free_suitors.append(worst)
+        if len(hospital.matching) > hospital.capacity:
+            worst = hospital.get_worst_match()
+            unmatch_pair(worst, hospital)
+            free_residents.append(worst)
 
-        if len(reviewer.matching) == reviewer.capacity:
-            successors = reviewer.get_successors(suitors)
+        if len(hospital.matching) == hospital.capacity:
+            successors = hospital.get_successors(residents)
             for successor in successors:
-                delete_pair(reviewer, successor)
+                delete_pair(hospital, successor)
                 if not successor.pref_names:
-                    free_suitors.remove(successor)
+                    free_residents.remove(successor)
 
     return {r: r.matching for r in hospitals}
 
 
-def hospital_optimal(residents, hospitals, verbose):
+def hospital_optimal(residents, hospitals):
     """ Solve the instance of HR to be hospital- (hospital-) optimal. The
     algorithm (originally described in `Roth1984`_) is as follows:
 
@@ -332,24 +332,24 @@ def hospital_optimal(residents, hospitals, verbose):
         hospital = free_hospitals.pop()
         resident = hospital.get_favourite(residents)
 
-        if suitor.matching:
-            curr_match = suitor.matching
-            unmatch_pair(suitor, curr_match)
-            if curr_match not in free_reviewers:
-                free_reviewers.append(curr_match)
+        if resident.matching:
+            curr_match = resident.matching
+            unmatch_pair(resident, curr_match)
+            if curr_match not in free_hospitals:
+                free_hospitals.append(curr_match)
 
-        match_pair(suitor, reviewer)
-        reviewer_match_names = [m.name for m in reviewer.matching]
-        if len(reviewer.matching) < reviewer.capacity and [
+        match_pair(resident, hospital)
+        hospital_match_names = [m.name for m in hospital.matching]
+        if len(hospital.matching) < hospital.capacity and [
             name
-            for name in reviewer.pref_names
-            if name not in reviewer_match_names
+            for name in hospital.pref_names
+            if name not in hospital_match_names
         ]:
-            free_reviewers.append(reviewer)
+            free_hospitals.append(hospital)
 
         successors = resident.get_successors(hospitals)
         for successor in successors:
-            delete_pair(suitor, successor)
+            delete_pair(resident, successor)
             successor_match_names = [m.name for m in successor.matching]
             if (
                 not [
@@ -357,8 +357,8 @@ def hospital_optimal(residents, hospitals, verbose):
                     for name in successor.pref_names
                     if name not in successor_match_names
                 ]
-                and successor in free_reviewers
+                and successor in free_hospitals
             ):
-                free_reviewers.remove(successor)
+                free_hospitals.remove(successor)
 
     return {r: r.matching for r in hospitals}

--- a/src/matching/solvers/student_allocation.py
+++ b/src/matching/solvers/student_allocation.py
@@ -1,0 +1,23 @@
+""" The Student Allocation Problem solver and core algorithm. """
+
+from matching import Game, Matching
+
+from .util import delete_pair, match_pair, unmatch_pair
+
+
+class StudentAllocation(Game):
+    """ A class for solving instances of the Student Allocation problem (SA)
+    using an adapted Gale-Shapley algorithm. """
+
+    def __init__(self, students, projects, lecturers):
+
+        for student in students:
+            student.matching = None
+        for player in projects + lecturers:
+            player.matching = []
+
+        self.students = students
+        self.projects = projects
+        self.lecturers = lecturers
+
+        super().__init__()

--- a/tests/hospital_resident/params.py
+++ b/tests/hospital_resident/params.py
@@ -56,6 +56,9 @@ def _make_hospitals(residents, capacities):
         for name in available_hospital_names
     ]
 
+    for hospital in hospitals:
+        hospital.matching = []
+
     return sorted(hospitals, key=lambda hosp: hosp.name)
 
 

--- a/tests/hospital_resident/params.py
+++ b/tests/hospital_resident/params.py
@@ -13,9 +13,9 @@ def _get_possible_prefs(names):
     """ Generate the list of all possible non-empty preference lists made from a
     list of names. """
 
-    all_ordered_subsets = set(
-        [tuple(set(sub)) for sub in it.product(names, repeat=len(names))]
-    )
+    all_ordered_subsets = {
+        tuple(set(sub)) for sub in it.product(names, repeat=len(names))
+    }
 
     possible_prefs = [
         list(perm)
@@ -43,7 +43,7 @@ def _make_residents(resident_names, hospital_names):
 def _make_hospitals(residents, capacities):
     """ Given some residents and capacities, make a valid set of hospitals. """
 
-    available_hospital_names = set([h for r in residents for h in r.pref_names])
+    available_hospital_names = {h for r in residents for h in r.pref_names}
 
     hospitals = [
         Player(

--- a/tests/student_allocation/params.py
+++ b/tests/student_allocation/params.py
@@ -44,12 +44,14 @@ def _make_lecturers(students, proj_lect_dict, capacities):
     """ Given some students, relations between projects and lecturers, and
     capacities, make a valid set of lecturers. """
 
-    available_lecturer_names = {
-        l
-        for s in students
-        for l, p in proj_lect_dict.items()
-        if p in s.pref_names
-    }
+    available_lecturer_names = []
+    for student in students:
+        for lect_name, proj_names in proj_lect_dict.item():
+            for proj_name in proj_names:
+                if proj_name in student.pref_names:
+                    available_lecturer_names.append(lect_name)
+
+    available_lecturer_names = set(available_lecturer_names)
 
     lect_stud_dict = {}
     for lect_name, proj_name in proj_lect_dict.items():

--- a/tests/student_allocation/params.py
+++ b/tests/student_allocation/params.py
@@ -1,0 +1,143 @@
+""" Toolkit for SA tests. """
+
+import itertools as it
+
+import numpy as np
+from hypothesis import given
+from hypothesis.strategies import dictionaries, integers, lists, sampled_from
+
+from matching import Player, StudentAllocation
+
+
+def _get_possible_prefs(names):
+    """ Generate the list of all possible non-empty preference lists made from a
+    list of names. """
+
+    all_ordered_subsets = {
+        tuple(set(sub)) for sub in it.product(names, repeat=len(names))
+    }
+
+    possible_prefs = [
+        list(perm)
+        for sub in all_ordered_subsets
+        for perm in it.permutations(sub)
+    ]
+
+    return possible_prefs
+
+
+def _make_students(student_names, project_names):
+    """ Given some names, make a valid set of students. """
+
+    possible_prefs = _get_possible_prefs(project_names)
+    students = [
+        Player(
+            name, possible_prefs[np.random.choice(range(len(possible_prefs)))]
+        )
+        for name in student_names
+    ]
+
+    return sorted(students, key=lambda stud: stud.name)
+
+
+def _make_lecturers(students, proj_lect_dict, capacities):
+    """ Given some students, relations between projects and lecturers, and
+    capacities, make a valid set of lecturers. """
+
+    available_lecturer_names = {
+        l
+        for s in students
+        for l, p in proj_lect_dict.items()
+        if p in s.pref_names
+    }
+
+    lect_stud_dict = {}
+    for lect_name, proj_name in proj_lect_dict.items():
+        for student in students:
+            if proj_name in student.pref_names:
+                try:
+                    lect_stud_dict[lect_name] += [student.name]
+                except KeyError:
+                    lect_stud_dict[lect_name] = [student.name]
+
+    lecturers = [
+        Player(
+            name,
+            np.random.permutation(lect_stud_dict[name]).tolist(),
+            capacities[name],
+        )
+        for name in available_lecturer_names
+    ]
+
+    return sorted(lecturers, key=lambda lect: lect.name)
+
+
+def _make_projects(students, lecturers, proj_lect_dict, capacities):
+    """ Given some students, lecturers and capacities, make a valid set of
+    projects. """
+
+    available_project_names = {p for s in students for p in s.pref_names}
+
+    projects = []
+    for lecturer in lecturers:
+        project_names = proj_lect_dict[lecturer.name]
+        for name in project_names:
+            if name in available_project_names:
+                pref_names = []
+                for student in students:
+                    if name in student.pref_names:
+                        pref_names.append(student.name)
+                pref_names.sort(key=lecturer.pref_names.index)
+
+                project = Player(name, pref_names, capacities[name])
+
+                projects.append(project)
+
+    return sorted(projects, key=lambda proj: proj.name)
+
+
+def _make_game(
+    student_names, proj_lect_dict, project_capacities, lecturer_capacities, seed
+):
+    """ Make all of the players and the game itself. """
+
+    np.random.seed(seed)
+    project_names = [
+        proj for projs in proj_lect_dict.values() for proj in projs
+    ]
+    students = _make_students(student_names, project_names)
+    lecturers = _make_lecturers(students, proj_lect_dict, lecturer_capacities)
+    projects = _make_projects(
+        students, lecturers, proj_lect_dict, project_capacities
+    )
+    game = StudentAllocation(students, projects, lecturers)
+
+    return students, projects, lecturers, game
+
+
+STUDENT_ALLOCATION = given(
+    student_names=lists(
+        elements=sampled_from(["A", "B", "C", "D"]),
+        min_size=1,
+        max_size=4,
+        unique=True,
+    ),
+    proj_lect_dict=dictionaries(
+        keys=sampled_from(["X", "Y", "Z"]),
+        values=lists(
+            elements=sampled_from(["J", "K", "L", "M", "N"]),
+            min_size=5,
+            max_size=5,
+        ),
+        min_size=3,
+        max_size=3,
+    ),
+    project_capacities=dictionaries(
+        keys=sampled_from(["J", "K", "L", "M", "N"]),
+        values=integers(min_value=1),
+    ),
+    lecturer_capacities=dictionaries(
+        keys=sampled_from(["X", "Y", "Z"]), values=integers(min_value=2)
+    ),
+    seed=integers(min_value=0, max_value=2 ** 32 - 1),
+)

--- a/tests/student_allocation/test_solver.py
+++ b/tests/student_allocation/test_solver.py
@@ -6,12 +6,8 @@ from .params import STUDENT_ALLOCATION, _make_game
 
 
 @STUDENT_ALLOCATION
-def test_init(
-    student_names,
-    proj_lect_dict,
-    project_capacities,
-    lecturer_capacities,
-    seed,
+def _test_init(
+    student_names, proj_lect_dict, project_capacities, lecturer_capacities, seed
 ):
     """ Test that an instance of StudentAllocation is created correctly. """
 

--- a/tests/student_allocation/test_solver.py
+++ b/tests/student_allocation/test_solver.py
@@ -1,0 +1,35 @@
+""" Unit tests for the SA solver. """
+
+from matching import StudentAllocation
+
+from .params import STUDENT_ALLOCATION
+
+
+@STUDENT_ALLOCATION
+def test_init(
+    student_names,
+    project_names,
+    lecturer_names,
+    project_capacities,
+    lecturer_capacities,
+    seed,
+):
+    """ Test that an instance of StudentAllocation is created correctly. """
+
+    students, projects, lecturers, match = _make_game(
+        student_names,
+        project_names,
+        lecturer_names,
+        project_capacities,
+        lecturer_capacities,
+        seed,
+    )
+
+    assert game.students == students
+    assert game.projects == projects
+    assert game.lecturers == lecturers
+    assert all([student.matching is None for student in game.students])
+    assert all([project.matching == [] for project in game.projects])
+    assert all([lecturer.matching == [] for lecturer in game.lecturers])
+    assert game.matching is None
+    assert game.blocking_pairs is None

--- a/tests/student_allocation/test_solver.py
+++ b/tests/student_allocation/test_solver.py
@@ -2,24 +2,22 @@
 
 from matching import StudentAllocation
 
-from .params import STUDENT_ALLOCATION
+from .params import STUDENT_ALLOCATION, _make_game
 
 
 @STUDENT_ALLOCATION
 def test_init(
     student_names,
-    project_names,
-    lecturer_names,
+    proj_lect_dict,
     project_capacities,
     lecturer_capacities,
     seed,
 ):
     """ Test that an instance of StudentAllocation is created correctly. """
 
-    students, projects, lecturers, match = _make_game(
+    students, projects, lecturers, game = _make_game(
         student_names,
-        project_names,
-        lecturer_names,
+        proj_lect_dict,
         project_capacities,
         lecturer_capacities,
         seed,

--- a/tests/unit/test_matching.py
+++ b/tests/unit/test_matching.py
@@ -36,6 +36,29 @@ def test_repr():
     matching = Matching()
     assert repr(matching) == "{}"
 
+    matching = Matching(dictionary)
+    assert repr(matching) == str(dictionary)
+
+
+def test_keys():
+    """ Check a Matching can have its `keys` accessed. """
+
+    matching = Matching()
+    assert list(matching.keys()) == []
+
+    matching = Matching(dictionary)
+    assert list(matching.keys()) == suitors
+
+
+def test_values():
+    """ Check a Matching can have its `values` accessed. """
+
+    matching = Matching()
+    assert list(matching.values()) == []
+
+    matching = Matching(dictionary)
+    assert list(matching.values()) == reviewers
+
 
 def test_getitem():
     """ Check that you can access items in a Matching correctly. """

--- a/tests/unit/test_player.py
+++ b/tests/unit/test_player.py
@@ -14,11 +14,7 @@ def test_init(name, pref_names, capacity):
     assert player.name == name
     assert player.pref_names == pref_names
     assert player.capacity == capacity
-    assert (
-        player.matching is None
-        if player.capacity == 1
-        else player.matching == []
-    )
+    assert player.matching is None
 
 
 @PLAYER
@@ -88,6 +84,9 @@ def test_match(name, pref_names, capacity):
     player = Player(name, pref_names, capacity)
     other = Player(pref_names[0], [name])
 
+    if player.capacity > 1:
+        player.matching = []
+
     player.match(other)
     assert (
         player.matching == other
@@ -119,12 +118,36 @@ def test_get_worst_match_idx(name, pref_names, capacity):
         key=lambda other: player.pref_names.index(other.name),
     )
 
+    if player.capacity > 1:
+        player.matching = []
+
     for i, other in enumerate(others):
         if player.capacity == 1:
             player.matching = other
         else:
             player.matching.append(other)
         assert player.get_worst_match_idx() == i
+
+
+@PLAYER
+def test_get_worst_match(name, pref_names, capacity):
+    """ Check that the worst current match can be obtained correctly. """
+
+    player = Player(name, pref_names, capacity)
+    others = sorted(
+        [Player(other, pref_names=[name]) for other in pref_names],
+        key=lambda other: player.pref_names.index(other.name),
+    )
+
+    if player.capacity > 1:
+        player.matching = []
+
+    for other in others:
+        if player.capacity == 1:
+            player.matching = other
+        else:
+            player.matching.append(other)
+        assert player.get_worst_match() == other
 
 
 @PLAYER

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -28,6 +28,8 @@ def test_match_pair(name, pref_names, capacity):
 
     for other in others:
         player = Player(name, pref_names, capacity)
+        if player.capacity > 1:
+            player.matching = []
         match_pair(player, other)
 
         assert (


### PR DESCRIPTION
Following #26, some tweaking has been included to speed up the processes in solving an instance of HR.

The main change is that instead of finding all the "free" players at the end of each iteration, they are added and dropped on the fly during the matching, unmatching and forgetting stages of the algorithm(s).

The effect of these tweaks was tested in a similar fashion to that done in #26 for a game with 400 residents and 20 hospitals. The runtime on my machine decreased from ~8s to ~2.5s for resident-optimality and from ~10s to ~0.5s for hospital-optimality.