### PR TITLE
Make SR more readable

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -99,7 +99,7 @@ Matching is a Python library that relies on one core library from the
 standard scientific Python stack -- NumPy [@numpy] -- that currently implements
 algorithms for four types of matching games:
 
-- The stable marriage problem (SM) [@gale1962];
+- the stable marriage problem (SM) [@gale1962];
 - the hospital-resident assignment problem (HR) [@gale1962; @roth1984];
 - the student-project allocation problem (SA) [@abra2007];
 - the stable roommates problem (SR) [@irvi1985].

--- a/src/matching/games/stable_roommates.py
+++ b/src/matching/games/stable_roommates.py
@@ -55,13 +55,13 @@ class StableRoommates(Game):
         for player in self.players:
             others = [p for p in self.players if p != player]
             for other in others:
-                both_matched = player.matching and other.matching
-                if both_matched:
+                if (other, player) not in blocking_pairs:
+                    both_matched = player.matching and other.matching
                     prefer_each_other = player.prefers(
                         other, player.matching
                     ) and other.prefers(player, other.matching)
-                    if prefer_each_other:
-                        blocking_pairs.append((player, other))
+                    if both_matched and prefer_each_other:
+                            blocking_pairs.append((player, other))
 
         self.blocking_pairs = blocking_pairs
         return not any(blocking_pairs)
@@ -215,7 +215,7 @@ def stable_roommates(players):
     if any(len(p.prefs) > 1 for p in players):
         players = second_phase(players)
 
-    return {p: p.matching for p in players}
+    return {player: player.matching for player in players}
 
 
 def _make_players(player_prefs):


### PR DESCRIPTION
Slightly clear up `StableRoommates.check_stability` method, and alter the output so `(A, B)` and `(B, A)` don't both get added to `blocking_pairs`.