### PR TITLE
Move to bibtex citations

### DIFF
--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -1,0 +1,90 @@
+@article{AIM07,
+    title = {Two algorithms for the Student-Project Allocation problem},
+    year = {2007},
+    author = {Abraham, David J. and Irving, Robert W. and Manlove, David F.},
+    journal = {5},
+    number = {1},
+    pages = {73-90},
+    doi = {10.1016/j.jda.2006.03.006},
+}
+
+@book{Aus13,
+    title = {Pride and Prejudice},
+    year = {1813},
+    author = {Austen, Jane},
+    publisher = {T. Egerton, Military Library, Whitehall, London, UK},
+}
+
+@article{DF81,
+    title = {Machiavelli and the Gale-Shapley Algorithm},
+    year = {1981},
+    author = {Dubins, Lester and Freedman, David},
+    journal = {Amaerican Mathematics Monthly},
+    volume = {88},
+    pages = {485-494},
+    doi = {10.2307/23212753}
+}
+
+@article{GS62,
+    title = {College Admissions and the Stability of Marriage},
+    author = {Gale, David and Shapley, Lloyd},
+    year = {1962},
+    journal = {The American Mathematical Monthly},
+    volume = {69},
+    number = {1},
+    pages = {9-15},
+    doi = {10.2307/2312726},
+}
+
+@article{Irv85,
+    title = {An efficient algorithm for the "stable roommates" problem},
+    author = {Irving, Robert W.},
+    year = {1985},
+    journal = {Journal of Algorithms},
+    volume = {6},
+    number = {4},
+    pages = {577-595},
+    doi = {10.1016/0196-6774(85)90033-1},
+}
+
+@article{KCH+16,
+    title = {An Open Framework for the Reproducible Study of the Iterated
+             Prisoner’s Dilemma},
+    year = {2016},
+    author = {Knight, Vincent and Campbell, Owen and Harper, Marc and Langner,
+              Karol M. and Campbell, James and Campbell, Thomas and Carney, Alex
+              and Chorley, Martin and Davidson-Pilon, Cameron and Glass,
+              Kristian and et al.},
+    journal = {Journal of Open Research Software},
+    volume = {4},
+    number = {1},
+    doi = {10.5334/jors.125},
+}
+
+@misc{MMT14,
+    title = {Gambit: Software Tools for Game Theory, Version 16.0.1},
+    year = {2014},
+    author = {McKelvey, Richard D. and McLennan, Andrew M. and Turocy, Theodore
+              L.},
+    url = {http://www.gambit-project.org},
+}
+
+@misc{KBRK19,
+    title = {Nashpy: v0.0.19},
+    year = {2019},
+    author = {Knight, Vincent and Baldevia, Ria and Rivière, Philippe and
+              Konovalov, Alexander},
+    doi = {10.5281/zenodo.3256475},
+}
+
+@article{Rot84,
+    title = {The Evolution of the Labor Market for Medical Interns and
+             Residents: A Case Study in Game Theory},
+    year = {1984},
+    author = {Roth, Alvin},
+    journal = {Journal of Political Economy},
+    volume = {92},
+    number = {6},
+    pages = {991-1016},
+    doi = {10.1086/261272},
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
     "sphinx.ext.napoleon",
+    "sphinxcontrib.bibtex",
     "nbsphinx",
 ]
 

--- a/docs/discussion/hospital_resident/algorithm.rst
+++ b/docs/discussion/hospital_resident/algorithm.rst
@@ -5,9 +5,9 @@ Finding optimal, stable matchings for HR is of great importance as it solves
 real-world problems. For instance, the `National Resident Matching Program
 <http://www.nrmp.org>`_ uses an algorithm like the one presented here to assign
 medical students in the US to hospitals. An algorithm which solves HR was
-originally presented in [Gale1962]_ but further work was done to improve on
-these algorithms in later years [Dubi1981]_, [Roth1984]_. Unlike the algorithm
-for SM, this algorithm takes a different form depending on the desired
+originally presented in :cite:`GS62` but further work was done to improve on
+these algorithms in later years :cite:`DF81`, :cite:`Rot84`. Unlike the
+algorithm for SM, this algorithm takes a different form depending on the desired
 optimality of the solution. Below are the resident-optimal and hospital-optimal
 algorithms for finding a unique, stable matching for an instance of HR.
 

--- a/docs/discussion/other_packages.rst
+++ b/docs/discussion/other_packages.rst
@@ -10,15 +10,15 @@ Python
 ------
 
 - `Axelrod <https://axelrod.readthedocs.io/en/stable/>`_: a research library
-  aimed at the study of the Iterated Prisoners Dilemma [Knig2016]_.
+  aimed at the study of the Iterated Prisoners Dilemma :cite:`KCH+16`.
 
 - `Gambit <http://www.gambit-project.org>`_: a C library with both a Python
   and online interface for the computation of equilibria in large games
-  [McKe2016]_.
+  :cite:`MMT14`.
 
 - `Nashpy <https://nashpy.readthedocs.io/en/stable/>`_: a library for the
   computation of Nash equilibria in two-player, normal form games with a number
-  of different algorithms [Nash2016]_.
+  of different algorithms :cite:`KBRK19`.
 
 - `PyNFG <https://pypi.org/project/PyNFG/>`_: a library for modelling network
   form games.

--- a/docs/discussion/stable_marriage/algorithm.rst
+++ b/docs/discussion/stable_marriage/algorithm.rst
@@ -2,7 +2,7 @@ The algorithm
 -------------
 
 David Gale and Lloyd Shapley presented an algorithm for solving SM in
-[Gale1962]_. In fact, the algorithm provides a unique, stable, suitor-optimal
+:cite:`GS62`. In fact, the algorithm provides a unique, stable, suitor-optimal
 matching for any instance of SM and is as follows:
 
 0. Assign all suitors and reviewers to be unmatched.

--- a/docs/discussion/stable_roommates/algorithm.rst
+++ b/docs/discussion/stable_roommates/algorithm.rst
@@ -2,7 +2,7 @@ The algorithm
 -------------
 
 Robert Irving presented an efficient algorithm for finding a stable matching to
-SR in [Irvi1985]_ if one exists. The algorithm comes in two phases:
+SR in :cite:`Irv85` if one exists. The algorithm comes in two phases:
 
 Phase 1
 +++++++

--- a/docs/discussion/student_allocation/algorithm.rst
+++ b/docs/discussion/student_allocation/algorithm.rst
@@ -8,10 +8,10 @@ this in the real world is described in more detail in `this tutorial
 
 As with HR, there are two algorithms implemented in Matching to solve instances
 of SA, one to handle the optimality of each party (students and
-project/supervisors). These algorithms, taken from [Abra2007]_, follow a similar
-structure to those for HR in that they take advantage of the inherent structure
-of the game. Again, each party-optimal algorithm provides a unique, stable
-matching for an instance of SA.
+project/supervisors). These algorithms, taken from :cite:`AIM07`, follow a
+similar structure to those for HR in that they take advantage of the inherent
+structure of the game. Again, each party-optimal algorithm provides a unique,
+stable matching for an instance of SA.
 
 Student-optimal
 +++++++++++++++

--- a/docs/reference/bibliography.rst
+++ b/docs/reference/bibliography.rst
@@ -4,36 +4,6 @@ Bibliography
 This is a collection of various bibliographic items referenced in the
 documentation.
 
-.. [Abra2007] Abraham, D.J., Irving, R.W. and Manlove, D.F. (2007). Two
-   algorithms for the Student-Project Allocation problem. Journal of Discrete
-   Algorithms, 5(1), 73-90. doi: 10.1016/j.jda.2006.03.006
-
-.. [Aust1813] Austen, J. (1813). Pride and Prejudice. Printed for T. Egerton,
-   Military Library, Whitehall. OCLC: 38659585
-
-.. [Dubi1981] Dubins, L. and)Freedman, D. (1981). Machiavelli and the
-   Gale-Shapley Algorithm. American Mathematics Monthly, 88, 485-494. 
-   doi: 10.2307/2321753
-
-.. [Gale1962] Gale, D. and Shapley, L. (1962). College Admissions and the
-   Stability of Marriage. The American Mathematical Monthly, 69(1), 9-15.
-   doi: 10.2307/2312726
-
-.. [Irvi1985] Irving, R.W. (1985). An efficient algorithm for the “stable
-   roommates” problem. Journal of Algorithms, 6(4), 577-595. doi:
-   10.1016/0196-6774(85)90033-1
-
-.. [Knig2016] Knight, V. et al. (2016). An Open Framework for the Reproducible
-   Study of the Iterated Prisoner’s Dilemma. Journal of Open Research Software.
-   4(1), p.e35. doi: 10.5334/jors.125
-
-.. [McKe2016] McKelvey, R.D., McLennan, A.M., and Turocy, T.L. (2016). Gambit:
-   Software Tools for Game Theory, Version 16.0.1.
-   http://www.gambit-project.org
-
-.. [Nash2016] The Nashpy project developers (2019). Nashpy: v0.0.19. doi:
-   10.5281/zenodo.3256475
-
-.. [Roth1984] Roth, A. (1984). The Evolution of the Labor Market for Medical
-   Interns and Residents: A Case Study in Game Theory. Journal of Political
-   Economy, 92(6), 991-1016. doi: 10.1086/261272
+.. bibliography:: ../bibliography.bib
+    :all:
+    :style: alpha

--- a/docs/reference/source/matching.games.rst
+++ b/docs/reference/source/matching.games.rst
@@ -20,6 +20,14 @@ matching.games.stable\_marriage module
    :undoc-members:
    :show-inheritance:
 
+matching.games.stable\_roommates module
+---------------------------------------
+
+.. automodule:: matching.games.stable_roommates
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 matching.games.student\_allocation module
 -----------------------------------------
 

--- a/docs/tutorials/hospital_resident/main.ipynb
+++ b/docs/tutorials/hospital_resident/main.ipynb
@@ -1,1 +1,210 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# Allocating university medics to hospital placements\n", "\n", "In this tutorial we will be solving a relatively large instance of HR. The residents, hospital capacities and all of the preferences in this instance are entirely fabricated but the hospitals are some of those from the South Wales area of the UK.\n", "\n", "---\n", "\n", "The data for this tutorial has been archived [here](https://zenodo.org/record/3688091/), and the source code used to generate it is available [on GitHub](https://github.com/daffidwilde/matching/blob/master/docs/tutorials/hospital_resident/data.py).\n", "\n", "Due to the size of this game, rather than manually creating `Player` instances for the players, and setting their preferences that way, we will use the `HospitalResident.create_from_dictionaries` method.\n", "\n", "As such, we will load in the data as Python dictionaries with the `urllib` and PyYAML libraries."]}, {"cell_type": "code", "execution_count": 1, "metadata": {}, "outputs": [], "source": ["import urllib\n", "import yaml\n"]}, {"cell_type": "code", "execution_count": 2, "metadata": {}, "outputs": [], "source": ["url = \"https://zenodo.org/record/3688091/files/residents.yml\"\n", "with urllib.request.urlopen(url) as response:\n", "    resident_preferences = yaml.full_load(response.read())\n", "\n", "\n", "url = \"https://zenodo.org/record/3688091/files/hospitals.yml\"\n", "with urllib.request.urlopen(url) as response:\n", "    hospital_preferences = yaml.full_load(response.read())\n", "\n", "\n", "url = \"https://zenodo.org/record/3688091/files/capacities.yml\"\n", "with urllib.request.urlopen(url) as response:\n", "    hospital_capacities = yaml.full_load(response.read())\n"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Thankfully, this data is already clean and the preference lists meet the conditions for a valid instance of HR (see its [discussion page](../../discussion/hospital_resident/index.rst) for more details).\n", "\n", "As has been stated, this game is quite large. In fact, there are 200 medics (residents) applying to 7 hospitals with a total of 210 spaces available:"]}, {"cell_type": "code", "execution_count": 3, "metadata": {}, "outputs": [{"data": {"text/plain": ["(200, 7, 210)"]}, "execution_count": 3, "metadata": {}, "output_type": "execute_result"}], "source": ["len(resident_preferences), len(hospital_preferences), sum(hospital_capacities.values())\n"]}, {"cell_type": "markdown", "metadata": {}, "source": ["---\n", "\n", "With the dictionaries read in, we can play the game. We have the option to find a resident- or hospital-optimal solution. In this case, as is often done in reality, we will be using the former."]}, {"cell_type": "code", "execution_count": 4, "metadata": {}, "outputs": [], "source": ["from matching.games import HospitalResident\n"]}, {"cell_type": "code", "execution_count": 5, "metadata": {}, "outputs": [], "source": ["game = HospitalResident.create_from_dictionaries(\n", "    resident_preferences, hospital_preferences, hospital_capacities\n", ")\n", "\n", "matching = game.solve(optimal=\"resident\")\n"]}, {"cell_type": "code", "execution_count": 6, "metadata": {}, "outputs": [{"data": {"text/plain": ["{Dewi Sant: [067, 022, 023, 158, 139, 065, 160, 131, 011, 137, 039, 045, 013, 046, 072, 037, 086, 152, 144, 154, 130, 040, 010, 159, 083, 019, 169, 193, 168, 079], Prince Charles: [027, 133, 106, 081, 051, 044, 069, 157, 110, 119, 129, 107, 135, 034, 007, 194, 198, 061, 087, 041, 183, 136, 059, 178, 009, 008, 031, 070, 026], Prince of Wales: [143, 128, 048, 175, 078, 132, 151, 030, 124, 138, 088, 004, 199, 173, 017, 097, 064, 025, 112, 181, 171, 196, 111, 035, 185, 156, 140, 001, 197, 177], Royal Glamorgan: [073, 118, 096, 089, 014, 126, 142, 053, 021, 018, 104, 015, 147, 153, 033, 113, 146, 076, 123, 042, 117, 024, 029, 000, 016, 134, 058, 166, 075, 174], Royal Gwent: [028, 105, 115, 095, 054, 006, 120, 161, 187, 164, 091, 141, 036, 184, 071, 155, 066, 182, 189, 002, 191, 068, 090, 145, 163, 121, 180], St. David: [149, 101, 150, 172, 165, 020, 049, 094, 060, 116, 056, 005, 093, 188, 043, 108, 192, 092, 167, 114, 012, 063, 077, 162, 085, 195, 032, 099, 084, 127], University: [109, 003, 057, 170, 176, 100, 122, 080, 038, 082, 102, 052, 062, 055, 047, 074, 050, 179, 125, 186, 148, 103, 098, 190]}"]}, "execution_count": 6, "metadata": {}, "output_type": "execute_result"}], "source": ["matching\n"]}, {"cell_type": "markdown", "metadata": {}, "source": ["We can check that this matching is both valid and stable using the methods below."]}, {"cell_type": "code", "execution_count": 7, "metadata": {}, "outputs": [], "source": ["assert game.check_validity()\n", "assert game.check_stability()\n"]}, {"cell_type": "markdown", "metadata": {}, "source": ["One thing that is of interest when solving games like this is whether all of the medics have been assigned. The following code allows us to see which residents (if any) were not matched to a hospital."]}, {"cell_type": "code", "execution_count": 8, "metadata": {}, "outputs": [{"data": {"text/plain": ["set()"]}, "execution_count": 8, "metadata": {}, "output_type": "execute_result"}], "source": ["matched_residents = []\n", "for _, residents in matching.items():\n", "    for resident in residents:\n", "        matched_residents.append(resident.name)\n", "\n", "unmatched_residents = set(resident_preferences.keys()) - set(matched_residents)\n", "unmatched_residents\n"]}, {"cell_type": "markdown", "metadata": {}, "source": ["So, this concludes the tutorial; every resident has successfully been assigned to a hospital of their choice with stability and fairness."]}, {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": []}], "metadata": {"kernelspec": {"display_name": "Matching docs", "language": "python", "name": "matching-docs"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.7.6"}}, "nbformat": 4, "nbformat_minor": 4}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Allocating university medics to hospital placements\n",
+    "\n",
+    "In this tutorial we will be solving a relatively large instance of HR. The residents, hospital capacities and all of the preferences in this instance are entirely fabricated but the hospitals are some of those from the South Wales area of the UK.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "The data for this tutorial has been archived [here](https://zenodo.org/record/3688091/), and the source code used to generate it is available [on GitHub](https://github.com/daffidwilde/matching/blob/master/docs/tutorials/hospital_resident/data.py).\n",
+    "\n",
+    "Due to the size of this game, rather than manually creating `Player` instances for the players, and setting their preferences that way, we will use the `HospitalResident.create_from_dictionaries` method.\n",
+    "\n",
+    "As such, we will load in the data as Python dictionaries with the `urllib` and PyYAML libraries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib\n",
+    "import yaml\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = \"https://zenodo.org/record/3688091/files/residents.yml\"\n",
+    "with urllib.request.urlopen(url) as response:\n",
+    "    resident_preferences = yaml.full_load(response.read())\n",
+    "\n",
+    "\n",
+    "url = \"https://zenodo.org/record/3688091/files/hospitals.yml\"\n",
+    "with urllib.request.urlopen(url) as response:\n",
+    "    hospital_preferences = yaml.full_load(response.read())\n",
+    "\n",
+    "\n",
+    "url = \"https://zenodo.org/record/3688091/files/capacities.yml\"\n",
+    "with urllib.request.urlopen(url) as response:\n",
+    "    hospital_capacities = yaml.full_load(response.read())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Thankfully, this data is already clean and the preference lists meet the conditions for a valid instance of HR (see its [discussion page](../../discussion/hospital_resident/index.rst) for more details).\n",
+    "\n",
+    "As has been stated, this game is quite large. In fact, there are 200 medics (residents) applying to 7 hospitals with a total of 210 spaces available:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(200, 7, 210)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(resident_preferences), len(hospital_preferences), sum(hospital_capacities.values())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "With the dictionaries read in, we can play the game. We have the option to find a resident- or hospital-optimal solution. In this case, as is often done in reality, we will be using the former."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matching.games import HospitalResident\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "game = HospitalResident.create_from_dictionaries(\n",
+    "    resident_preferences, hospital_preferences, hospital_capacities\n",
+    ")\n",
+    "\n",
+    "matching = game.solve(optimal=\"resident\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{Dewi Sant: [067, 022, 023, 158, 139, 065, 160, 131, 011, 137, 039, 045, 013, 046, 072, 037, 086, 152, 144, 154, 130, 040, 010, 159, 083, 019, 169, 193, 168, 079], Prince Charles: [027, 133, 106, 081, 051, 044, 069, 157, 110, 119, 129, 107, 135, 034, 007, 194, 198, 061, 087, 041, 183, 136, 059, 178, 009, 008, 031, 070, 026], Prince of Wales: [143, 128, 048, 175, 078, 132, 151, 030, 124, 138, 088, 004, 199, 173, 017, 097, 064, 025, 112, 181, 171, 196, 111, 035, 185, 156, 140, 001, 197, 177], Royal Glamorgan: [073, 118, 096, 089, 014, 126, 142, 053, 021, 018, 104, 015, 147, 153, 033, 113, 146, 076, 123, 042, 117, 024, 029, 000, 016, 134, 058, 166, 075, 174], Royal Gwent: [028, 105, 115, 095, 054, 006, 120, 161, 187, 164, 091, 141, 036, 184, 071, 155, 066, 182, 189, 002, 191, 068, 090, 145, 163, 121, 180], St. David: [149, 101, 150, 172, 165, 020, 049, 094, 060, 116, 056, 005, 093, 188, 043, 108, 192, 092, 167, 114, 012, 063, 077, 162, 085, 195, 032, 099, 084, 127], University: [109, 003, 057, 170, 176, 100, 122, 080, 038, 082, 102, 052, 062, 055, 047, 074, 050, 179, 125, 186, 148, 103, 098, 190]}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matching\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can check that this matching is both valid and stable using the methods below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert game.check_validity()\n",
+    "assert game.check_stability()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One thing that is of interest when solving games like this is whether all of the medics have been assigned. The following code allows us to see which residents (if any) were not matched to a hospital."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "set()"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matched_residents = []\n",
+    "for _, residents in matching.items():\n",
+    "    for resident in residents:\n",
+    "        matched_residents.append(resident.name)\n",
+    "\n",
+    "unmatched_residents = set(resident_preferences.keys()) - set(matched_residents)\n",
+    "unmatched_residents\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So, this concludes the tutorial; every resident has successfully been assigned to a hospital of their choice with stability and fairness."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Matching docs",
+   "language": "python",
+   "name": "matching-docs"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/tutorials/stable_marriage/main.ipynb
+++ b/docs/tutorials/stable_marriage/main.ipynb
@@ -2,12 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
    "source": [
     "# Finding a solution to a stable marriage game\n",
     "\n",
-    "\n",
-    "In this tutorial we will be setting up and solving an instance of SM with Matching. In particular, we will be using an example adapted from *Pride and Prejudice* [\\[Aust1813\\]](../../reference/bibliography.rst#Aust1813) where four women (Charlotte, Elizabeth, Jane and Lydia) are being courted by four male suitors (Bingley, Collins, Darcy, Wickham).\n",
+    "In this tutorial we will be setting up and solving an instance of SM with Matching. In particular, we will be using an example adapted from *Pride and Prejudice* [[Aus13]](../../reference/bibliography.rst) where four women (Charlotte, Elizabeth, Jane and Lydia) are being courted by four male suitors (Bingley, Collins, Darcy, Wickham).\n",
     "\n",
     "From here on out, we'll refer to the men and women as suitors and reviewers, respectively. If you'd like to know more about SM then head to its [discussion page](../../discussion/stable_marriage/index.rst).\n",
     "\n",
@@ -78,7 +79,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -100,6 +103,7 @@
   }
  ],
  "metadata": {
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Matching docs",
    "language": "python",

--- a/src/matching/games/hospital_resident.py
+++ b/src/matching/games/hospital_resident.py
@@ -13,6 +13,7 @@ class HospitalResident(Game):
 
     In this case, a blocking pair is any resident-hospital pair that satisfies
     **all** of the following:
+
         - They are present in each other's preference lists;
         - either the resident is unmatched, or they prefer the hospital to their
           current match;
@@ -239,10 +240,11 @@ def unmatch_pair(resident, hospital):
 
 
 def hospital_resident(residents, hospitals, optimal="resident"):
-    """ Solve an instance of HR using an adapted Gale-Shapley algorithm. A
-    unique, stable and optimal matching is found for the given set of residents
-    and hospitals. The optimality of the matching is found with respect to one
-    party and is subsequently the worst stable matching for the other.
+    """ Solve an instance of HR using an adapted Gale-Shapley algorithm
+    :cite:`Rot84`. A unique, stable and optimal matching is found for the given
+    set of residents and hospitals. The optimality of the matching is found with
+    respect to one party and is subsequently the worst stable matching for the
+    other.
 
     Parameters
     ----------

--- a/src/matching/games/stable_roommates.py
+++ b/src/matching/games/stable_roommates.py
@@ -196,7 +196,7 @@ def second_phase(players):
 
 
 def stable_roommates(players):
-    """ Irving's algorithm `[Irvi1984]`_ that finds stable solutions to
+    """ Irving's algorithm :cite:`Irv85` that finds stable solutions to
     instances of SR if one exists. Otherwise, an incomplete matching is found.
 
     Parameters


### PR DESCRIPTION
To make maintaining the bibliography easier, the `sphinxcontrib-bibtex` extension is to be used.

Bibliography style is `alpha` and is also used for [the bib keys](https://build-me-the-docs-please.readthedocs.io/en/latest/Using_Sphinx/UsingBibTeXCitationsInSphinx.html).