### PR TITLE
Fix documentation for JOSS review

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,10 +195,20 @@ autosummary_generate = [
     "reference/source/modules.rst",
 ]
 
-# nbsphinx_prolog = """
-# Go there: https://github.com/daffidwilde/matching/blob/docs/{{ env.doc2path(env.docname, base=None) }}
-# ----
-# """
+nbsphinx_prolog = """
+
+{% set docname = 'docs/' + env.doc2path(env.docname, base=None) %}
+
+.. raw:: html
+
+    <div class="admonition note">
+      <p>This page was generated from
+        <a class="reference external"
+        href="https://github.com/daffidwilde/matching/blob/master/{{ docname|e }}">{{ docname|e }}</a>.
+      </p>
+    </div>
+
+"""
 
 nbsphinx_epilog = """
 ----

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,3 +12,4 @@ dependencies:
         - matching
         - nbsphinx
         - sphinx_rtd_theme
+        - sphinxcontrib-bibtex

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,4 +36,3 @@ Indices and tables
 
 * :ref:`genindex`
 * :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
As part of [the review](https://github.com/openjournals/joss-reviews/issues/2169) for the paper supporting matching, some issues appeared around the documentation:

1. The empty "How To..." page (fixed in 4d407b0)
2. The empty "Search Page" at the end of the index page (fixed in 9db1d83)
3. Some details for users with multiple Python versions installed.

This PR addresses each of these points.