### PR TITLE
Update README (and supporting files) for JOSS review

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,26 @@
+If you are interested in contributing to the Matching library then first of all
+we would like to offer our thanks and say welcome!
+
+Whether you're looking to provide a fix for a current `issue
+<https://github.com/daffidwilde/matching/issues>`_, report a bug or implement a
+new feature to the library, your contributions are always welcome. Pull requests
+are a good place to discuss contributions so please do not feel you must present
+a perfect product from the off.
+
+To make a contribution via a pull request, follow these steps:
+
+1. Go to the `GitHub repo <https://github.com/daffidwilde/matching>`_,
+   make a fork, and clone the repo locally::
+
+       $ git clone git@github.com/<your-username>/matching.git
+
+2. Assuming you have all the dependencies installed, the next step is to ensure
+   that all the tests pass (this should not take very long at all)::
+
+       $ cd matching
+       $ pytest tests
+
+3. Make your changes and write tests to go with them -- ensuring they pass, too.
+
+4. Push to your fork and open a pull request.
+

--- a/README.rst
+++ b/README.rst
@@ -205,4 +205,4 @@ Get in contact!
 
 I hope this package is useful, and feel free to contact me here (or on Twitter:
 `@daffidwilde <https://twitter.com/daffidwilde>`_) with any issues or
-recommendations. PRs always welcome!
+recommendations. Pull requests are always welcome!

--- a/README.rst
+++ b/README.rst
@@ -200,11 +200,6 @@ solved in less than one tenth of a second:
 >>> _ = game.solve() # 48.6 ms ± 963 µs per loop
 
 
-Documentation
--------------
-
-Full documentation is available here: `<https://matching.readthedocs.io>`_
-
 Get in contact!
 ---------------
 

--- a/docs/reference/contributing.rst
+++ b/docs/reference/contributing.rst
@@ -1,28 +1,4 @@
 Contributing to the library
 ===========================
 
-If you are interested in contributing to the Matching library then first of all
-we would like to offer our thanks and say welcome!
-
-Whether you're looking to provide a fix for a current `issue
-<https://github.com/daffidwilde/matching/issues>`_, report a bug or implement a
-new feature to the library, your contributions are always welcome. Pull requests
-(PRs) are a good place to discuss contributions so please do not feel you must
-present a perfect product from the off.
-
-To make a contribution via a PR, follow these steps:
-
-1. Go to the `GitHub repo <https://github.com/daffidwilde/matching>`_,
-   make a fork, and clone the repo locally::
-
-       $ git clone git@github.com/<your-username>/matching.git
-
-2. Assuming you have all the dependencies installed, the next step is to ensure
-   that all the tests pass (this should not take very long at all)::
-
-       $ cd matching
-       $ pytest tests
-
-3. Make your changes and write tests to go with them -- ensuring they pass, too.
-
-4. Push to your fork and open a pull request.
+.. include:: ../../CONTRIBUTING.rst


### PR DESCRIPTION
This PR addresses the following points raised in [the review](https://github.com/openjournals/joss-reviews/issues/2169):

1. The use of "PR" over "pull request" in the README (fixed in 223378a)
2. The same issue in the "Contributing to the library" page of the documentation (fixed in 3a70a74).

In addition to these, a couple of minor changes have been incorporated: a duplicate section in the README has been removed, and an independent CONTRIBUTING file has been added to the top level of the repository.