### PR TITLE
Fix flaky `Player.forget()` behaviour

### DIFF
--- a/src/matching/player.py
+++ b/src/matching/player.py
@@ -58,12 +58,7 @@ class Player:
         list. """
 
         prefs = self.prefs[:]
-
-        try:
-            prefs.remove(other)
-        except ValueError:
-            pass
-
+        prefs.remove(other)
         self.prefs = prefs
 
     def get_successors(self):

--- a/tests/stable_roommates/test_algorithm.py
+++ b/tests/stable_roommates/test_algorithm.py
@@ -50,7 +50,7 @@ def test_second_phase(player_names, seed):
                 assert player.prefs == [player.matching]
             else:
                 assert player.matching is None
-    except IndexError:
+    except (IndexError, ValueError):
         pass
 
 


### PR DESCRIPTION
Occasionally `test_second_phase` would fail due to a repeated pair in an all-or-nothing cycle unless the try-except block is included in `Player.forget()`. However, this would never really happen in SR so an example can't be found and 100% coverage becomes flaky.

So, this PR removes the block (since it isn't needed) and adds `ValueError` to the exceptions in `test_second_phase`. This is a quick fix and perhaps a more appropriate solution is to make our own `MatchingError` exceptions?