### PR TITLE
Add Python requirement to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,6 @@ setup(
     keywords=["game-theory gale-shapley matching-games"],
     packages=find_packages("src"),
     package_dir={"": "src"},
+    python_requires=">=3.5",
     tests_require=["pytest", "numpy"],
 )


### PR DESCRIPTION
As per discussion [here](https://github.com/openjournals/joss-reviews/issues/2169#issuecomment-606754017), a `python_requires` parameter is added to the `setup.py` so that `pip install matching` will fail for any version of Python under 3.5.

I can't stop the install failing for `python setup.py <mode>`, however.