### PR TITLE
Make Game a metaclass

### DIFF
--- a/src/matching/__init__.py
+++ b/src/matching/__init__.py
@@ -1,6 +1,6 @@
 """ Top-level imports only. """
 
-from .game import Game
+from .game import BaseGame
 from .matching import Matching
 from .player import Player
 from .version import __version__

--- a/src/matching/game.py
+++ b/src/matching/game.py
@@ -1,11 +1,9 @@
 """ The base game class for facilitating and solving matching games. """
 
+import abc
 
-class Game:
-    """ A class to store information about, and facilitate the solving of, a
-    matching game.
-
-    **This is a base class and is not intended for use other than inheritance.**
+class BaseGame(metaclass=abc.ABCMeta):
+    """ An abstract base class for facilitating various matching games.
 
     Attributes
     ----------
@@ -36,17 +34,14 @@ class Game:
 
         return self._matching
 
+    @abc.abstractmethod
     def solve(self):
         """ Placeholder for solving the given matching game. """
 
-        raise NotImplementedError()
-
+    @abc.abstractmethod
     def check_stability(self):
         """ Placeholder for checking the stability of the current matching. """
 
-        raise NotImplementedError()
-
+    @abc.abstractmethod
     def check_validity(self):
         """ Placeholder for checking the validity of the current matching. """
-
-        raise NotImplementedError()

--- a/src/matching/games/hospital_resident.py
+++ b/src/matching/games/hospital_resident.py
@@ -1,13 +1,13 @@
 """ The HR solver and algorithm. """
 
-from matching import Game, Matching
+from matching import BaseGame, Matching
 from matching import Player as Resident
 from matching.players import Hospital
 
 from .util import delete_pair, match_pair
 
 
-class HospitalResident(Game):
+class HospitalResident(BaseGame):
     """ A class for solving instances of the hospital-resident assignment
     problem (HR).
 

--- a/src/matching/games/stable_marriage.py
+++ b/src/matching/games/stable_marriage.py
@@ -1,11 +1,11 @@
 """ The SM solver and algorithm. """
 
-from matching import Game, Matching, Player
+from matching import BaseGame, Matching, Player
 
 from .util import delete_pair, match_pair
 
 
-class StableMarriage(Game):
+class StableMarriage(BaseGame):
     """ A class for solving instances of the stable marriage problem (SM).
 
     Parameters

--- a/src/matching/games/stable_roommates.py
+++ b/src/matching/games/stable_roommates.py
@@ -1,11 +1,11 @@
 """ The SR solver and algorithm. """
 
-from matching import Game, Matching, Player
+from matching import BaseGame, Matching, Player
 
 from .util import delete_pair, match_pair
 
 
-class StableRoommates(Game):
+class StableRoommates(BaseGame):
     """ A class for solving instances of the stable roommates problem (SR).
 
     Parameters

--- a/src/matching/games/student_allocation.py
+++ b/src/matching/games/student_allocation.py
@@ -1,13 +1,13 @@
 """ The SA solver and algorithm. """
 
-from matching import Game, Matching
+from matching import BaseGame, Matching
 from matching import Player as Student
 from matching.players import Project, Supervisor
 
 from .util import delete_pair, match_pair
 
 
-class StudentAllocation(Game):
+class StudentAllocation(BaseGame):
     """ A class for solving instances of the student-allocation problem (SA)
     using an adapted Gale-Shapley algorithm.
 

--- a/tests/unit/test_game.py
+++ b/tests/unit/test_game.py
@@ -1,41 +1,54 @@
-""" Tests for the Game class. """
+""" Tests for the BaseGame class. """
 
 import pytest
 
-from matching import Game
+from matching import BaseGame
+
+
+class DummyGame(BaseGame):
+
+    def solve(self):
+        raise NotImplementedError()
+
+    def check_stability(self):
+        raise NotImplementedError()
+
+    def check_validity(self):
+        raise NotImplementedError()
 
 
 def test_init():
-    """ Test the default parameters makes a valid instance of Game. """
+    """ Test the default parameters makes a valid instance of BaseGame. """
 
-    match = Game()
+    match = DummyGame()
 
+    assert isinstance(match, BaseGame)
     assert match.matching is None
     assert match.blocking_pairs is None
 
 
 def test_no_solve():
-    """ Verify Game raises a NotImplementedError when calling the `solve`
+    """ Verify BaseGame raises a NotImplementedError when calling the `solve`
     method. """
 
     with pytest.raises(NotImplementedError):
-        match = Game()
+        match = DummyGame()
         match.solve()
 
 
 def test_no_check_stability():
-    """ Verify Game raises a NotImplementedError when calling the
+    """ Verify BaseGame raises a NotImplementedError when calling the
     `check_stability` method. """
 
     with pytest.raises(NotImplementedError):
-        match = Game()
+        match = DummyGame()
         match.check_stability()
 
 
 def test_no_check_validity():
-    """ Verify Game raises a NotImplementError when calling the
+    """ Verify BaseGame raises a NotImplementError when calling the
     `check_validity` method. """
 
     with pytest.raises(NotImplementedError):
-        match = Game()
+        match = DummyGame()
         match.check_validity()


### PR DESCRIPTION
As is discussed in #90, changing the `Game` class to a metaclass highlights that it should not be instantiated. In fact, by making it a subclass of `abc.ABCMeta` and decorating its methods as `abc.abstractmethod` stops this all together.

Thanks to @igarizio for this suggestion.