### PR TITLE
Remove `matching` property

### DIFF
--- a/src/matching/game.py
+++ b/src/matching/game.py
@@ -21,20 +21,8 @@ class Game:
 
     def __init__(self):
 
-        self._matching = None
+        self.matching = None
         self.blocking_pairs = None
-
-    @property
-    def matching(self):
-        """ Property method to stop direct write access. """
-
-        return self._matching
-
-    @matching.getter
-    def matching(self):
-        """ Property method to stop direct write access. """
-
-        return self._matching
 
     def solve(self):
         """ Placeholder for solving the given matching game. """

--- a/src/matching/games/hospital_resident.py
+++ b/src/matching/games/hospital_resident.py
@@ -66,7 +66,7 @@ class HospitalResident(Game):
         """ Solve the instance of HR using either the resident- or
         hospital-oriented algorithm. Return the matching. """
 
-        self._matching = Matching(
+        self.matching = Matching(
             hospital_resident(self.residents, self.hospitals, optimal)
         )
         return self.matching

--- a/src/matching/games/stable_marriage.py
+++ b/src/matching/games/stable_marriage.py
@@ -49,7 +49,7 @@ class StableMarriage(Game):
         """ Solve the instance of SM using either the suitor- or
         reviewer-oriented Gale-Shapley algorithm. Return the matching. """
 
-        self._matching = Matching(
+        self.matching = Matching(
             stable_marriage(self.suitors, self.reviewers, optimal)
         )
         return self.matching

--- a/src/matching/games/stable_roommates.py
+++ b/src/matching/games/stable_roommates.py
@@ -40,7 +40,7 @@ class StableRoommates(Game):
         """ Solve the instance of SR using Irving's algorithm. Return the
         matching. """
 
-        self._matching = Matching(stable_roommates(self.players))
+        self.matching = Matching(stable_roommates(self.players))
         return self.matching
 
     def check_stability(self):

--- a/src/matching/games/student_allocation.py
+++ b/src/matching/games/student_allocation.py
@@ -87,7 +87,7 @@ class StudentAllocation(Game):
         """ Solve the instance of SA using either the student- or
         supervisor-optimal algorithm. """
 
-        self._matching = Matching(
+        self.matching = Matching(
             student_allocation(
                 self.students, self.projects, self.supervisors, optimal
             )


### PR DESCRIPTION
The `Game` class uses a hidden `_matching` attribute and a `matching` property without a `setter` method. The reasons for doing this were never solved entirely, and its inclusion detracts from the implementation so it's best to remove it.