### PR TITLE
Pin sphinx version

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,6 +8,7 @@ dependencies:
     - ipython>=7.6
     - python>=3.6
     - pip>=19
+    - sphinx=2.4.0
     - pip:
         - matching
         - nbsphinx

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx>=2.0
+sphinx==2.4.0
 nbsphinx
 ipython>=7.6

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==2.4.0
+sphinx
 nbsphinx
 ipython>=7.6


### PR DESCRIPTION
Docs weren't building consistently so I've pinned sphinx in `docs/environment.yml` to `2.4.0` as this was the last consistent version.