### PR TITLE
Add to `matching` exceptions

### DIFF
--- a/src/matching/exceptions.py
+++ b/src/matching/exceptions.py
@@ -4,6 +4,15 @@
 class MatchingError(Exception):
     """ A generic error for when something is wrong with an internal object. """
 
+    def __init__(self, **kwargs):
+
+        for key, val in kwargs.items():
+            self.__setattr__(key, val)
+
+        self.message = kwargs
+
+        super().__init__(self.message)
+
 
 class PreferencesChangedWarning(UserWarning):
     """ A warning for when the preferences of a player are invalid. """

--- a/src/matching/exceptions.py
+++ b/src/matching/exceptions.py
@@ -1,5 +1,8 @@
 """ Exceptions for game solver checks. """
 
+class MatchingError(Exception):
+    """ A generic error for when something is wrong with an internal object. """
+
 
 class PreferencesChangedWarning(UserWarning):
     """ A warning for when the preferences of a player are invalid. """

--- a/src/matching/exceptions.py
+++ b/src/matching/exceptions.py
@@ -1,5 +1,6 @@
 """ Exceptions for game solver checks. """
 
+
 class MatchingError(Exception):
     """ A generic error for when something is wrong with an internal object. """
 

--- a/src/matching/exceptions.py
+++ b/src/matching/exceptions.py
@@ -1,11 +1,11 @@
-""" Warnings for game input checks. """
+""" Exceptions for game solver checks. """
 
 
-class InvalidPreferencesWarning(UserWarning):
+class PreferencesChangedWarning(UserWarning):
     """ A warning for when the preferences of a player are invalid. """
 
 
-class InvalidCapacityWarning(UserWarning):
+class CapacityChangedWarning(UserWarning):
     """ A warning for when the capacity of a player is invalid. """
 
 

--- a/src/matching/games/hospital_resident.py
+++ b/src/matching/games/hospital_resident.py
@@ -4,8 +4,8 @@ import warnings
 
 from matching import BaseGame, Matching
 from matching import Player as Resident
+from matching.exceptions import PlayerExcludedWarning, PreferencesChangedWarning
 from matching.players import Hospital
-from matching.warning import InvalidPreferencesWarning, PlayerExcludedWarning
 
 from .util import delete_pair, match_pair
 
@@ -183,7 +183,7 @@ class HospitalResident(BaseGame):
             for hospital in resident.prefs:
                 if hospital not in self.hospitals:
                     warnings.warn(
-                        InvalidPreferencesWarning(
+                        PreferencesChangedWarning(
                             f"{resident} has ranked a non-hospital: {hospital}."
                         )
                     )
@@ -213,7 +213,7 @@ class HospitalResident(BaseGame):
             for resident in hospital.prefs:
                 if hospital not in resident.prefs:
                     warnings.warn(
-                        InvalidPreferencesWarning(
+                        PreferencesChangedWarning(
                             f"{hospital} ranked {resident} but they did not. "
                             f"Removing {resident} from {hospital} preferences."
                         )
@@ -233,7 +233,7 @@ class HospitalResident(BaseGame):
             for resident in residents_that_ranked:
                 if resident not in hospital.prefs:
                     warnings.warn(
-                        InvalidPreferencesWarning(
+                        PreferencesChangedWarning(
                             f"{resident} ranked {hospital} but they did not. "
                             f"Removing {hospital} from {resident} preferences."
                         )

--- a/src/matching/games/stable_marriage.py
+++ b/src/matching/games/stable_marriage.py
@@ -3,6 +3,7 @@
 import copy
 
 from matching import BaseGame, Matching, Player
+from matching.exceptions import MatchingError
 
 from .util import delete_pair, match_pair
 
@@ -57,6 +58,22 @@ class StableMarriage(BaseGame):
         )
         return self.matching
 
+    def check_validity(self):
+        """ Check whether the current matching is valid. """
+
+        unmatched_issues = self._check_for_unmatched_players()
+        not_in_matching_issues = self._check_for_players_not_in_matching()
+        inconsistency_issues = self._check_for_inconsistent_matches()
+
+        if unmatched_issues or not_in_matching_issues or inconsistency_issues:
+            raise MatchingError(
+                unmatched_players=unmatched_issues,
+                players_not_in_matching=not_in_matching_issues,
+                inconsistent_matches=inconsistency_issues,
+            )
+
+        return True
+
     def check_stability(self):
         """ Check for the existence of any blocking pairs in the current
         matching, thus determining the stability of the matching. """
@@ -72,60 +89,45 @@ class StableMarriage(BaseGame):
         self.blocking_pairs = blocking_pairs
         return not any(blocking_pairs)
 
-    def check_validity(self):
-        """ Check whether the current matching is valid. """
-
-        self._check_all_matched()
-        self._check_matching_consistent()
-        return True
-
-    def _check_all_matched(self):
+    def _check_for_unmatched_players(self):
         """ Check everyone has a match. """
 
-        errors = []
+        issues = []
         for player in self.suitors + self.reviewers:
-            if player.matching is None:
-                errors.append(ValueError(f"{player} is unmatched."))
-            if player not in list(self.matching.keys()) + list(
-                self.matching.values()
-            ):
-                errors.append(
-                    ValueError(f"{player} does not appear in matching.")
-                )
+            issue = player.check_if_match_is_unacceptable(unmatched_okay=False)
+            if issue:
+                issues.append(issue)
 
-        if errors:
-            raise Exception(*errors)
+        return issues
 
-        return True
+    def _check_for_players_not_in_matching(self):
+        """ Check that everyone appears in the matching. """
 
-    def _check_matching_consistent(self):
-        """ Check that the game matching is consistent with the players. """
+        players_in_matching = set(self.matching.keys()) | set(
+            self.matching.values()
+        )
 
-        errors = []
+        issues = []
+        for player in self.suitors + self.reviewers:
+            if player not in players_in_matching:
+                issues.append(f"{player} does not appear in matching.")
+
+        return issues
+
+    def _check_for_inconsistent_matches(self):
+        """ Check that the game matching is consistent with those of the
+        players. """
+
+        issues = []
         matching = self.matching
-        for suitor in self.suitors:
-            if suitor.matching != matching[suitor]:
-                errors.append(
-                    ValueError(
-                        f"{suitor} is matched to {suitor.matching} but matching"
-                        f" says {matching[suitor]}."
-                    )
+        for suitor, reviewer in self.matching.items():
+            if suitor.matching != reviewer:
+                issues.append(
+                    f"{suitor} is matched to {suitor.matching} but the "
+                    f"matching says they should be matched to {reviewer}."
                 )
 
-        for reviewer in self.reviewers:
-            suitor = [s for s in matching if matching[s] == reviewer][0]
-            if reviewer.matching != suitor:
-                errors.append(
-                    ValueError(
-                        f"{reviewer} is matched to {reviewer.matching} but "
-                        f"matching says {suitor}."
-                    )
-                )
-
-        if errors:
-            raise Exception(*errors)
-
-        return True
+        return issues
 
     def _check_inputs(self):
         """ Raise an error if any of the conditions of the game have been

--- a/src/matching/games/stable_roommates.py
+++ b/src/matching/games/stable_roommates.py
@@ -3,6 +3,7 @@
 import copy
 
 from matching import BaseGame, Matching, Player
+from matching.exceptions import MatchingError
 
 from .util import delete_pair, match_pair
 
@@ -46,6 +47,21 @@ class StableRoommates(BaseGame):
         self.matching = Matching(stable_roommates(self.players))
         return self.matching
 
+    def check_validity(self):
+        """ Check whether the current matching is valid. Raise `MatchingError`
+        detailing the issues if not. """
+
+        issues = []
+        for player in self.players:
+            issue = player.check_if_match_is_unacceptable(unmatched_okay=False)
+            if issue:
+                issues.append(issue)
+
+        if issues:
+            raise MatchingError(unmatched_players=issues)
+
+        return True
+
     def check_stability(self):
         """ Check for the existence of any blocking pairs in the current
         matching. Then the stability of the matching holds when there are no
@@ -68,19 +84,6 @@ class StableRoommates(BaseGame):
 
         self.blocking_pairs = blocking_pairs
         return not any(blocking_pairs)
-
-    def check_validity(self):
-        """ Check whether the current matching is valid. """
-
-        errors = []
-        matching = self.matching
-        for player in self.players:
-            if player.matching is None:
-                errors.append(ValueError(f"{player} is unmatched."))
-        if errors:
-            raise Exception(*errors)
-
-        return True
 
     def _check_inputs(self):
         """ Check that all players have ranked all other players. """

--- a/src/matching/games/student_allocation.py
+++ b/src/matching/games/student_allocation.py
@@ -4,12 +4,12 @@ import warnings
 
 from matching import BaseGame, Matching
 from matching import Player as Student
-from matching.players import Project, Supervisor
-from matching.warning import (
-    InvalidCapacityWarning,
-    InvalidPreferencesWarning,
+from matching.exceptions import (
+    CapacityChangedWarning,
     PlayerExcludedWarning,
+    PreferencesChangedWarning,
 )
+from matching.players import Project, Supervisor
 
 from .util import delete_pair, match_pair
 
@@ -280,7 +280,7 @@ class StudentAllocation(BaseGame):
             for project in student.prefs:
                 if project not in self.projects:
                     warnings.warn(
-                        InvalidPreferencesWarning(
+                        PreferencesChangedWarning(
                             f"{student} has ranked a non-project: {project}."
                         )
                     )
@@ -310,7 +310,7 @@ class StudentAllocation(BaseGame):
             for student in project.prefs:
                 if project not in student.prefs:
                     warnings.warn(
-                        InvalidPreferencesWarning(
+                        PreferencesChangedWarning(
                             f"{project} ranked {student} but they did not. "
                             f"Removing {student} from {project} preferences."
                         )
@@ -330,7 +330,7 @@ class StudentAllocation(BaseGame):
             for student in students_that_ranked:
                 if student not in project.prefs:
                     warnings.warn(
-                        InvalidPreferencesWarning(
+                        PreferencesChangedWarning(
                             f"{student} ranked {project} but they did not. "
                             f"Removing {project} from {student} preferences."
                         )
@@ -363,7 +363,7 @@ class StudentAllocation(BaseGame):
                 }
                 if supervisor not in student_prefs_supervisors:
                     warnings.warn(
-                        InvalidPreferencesWarning(
+                        PreferencesChangedWarning(
                             f"{supervisor} ranked {student} but they have not "
                             "ranked one of their projects."
                         )
@@ -390,7 +390,7 @@ class StudentAllocation(BaseGame):
             for student in students_that_ranked:
                 if student not in supervisor.prefs:
                     warnings.warn(
-                        InvalidPreferencesWarning(
+                        PreferencesChangedWarning(
                             f"{student} ranked a project provided by "
                             f"{supervisor} but they did not."
                         )
@@ -399,7 +399,7 @@ class StudentAllocation(BaseGame):
                     for project in student.prefs:
                         if project.supervisor == supervisor:
                             warnings.warn(
-                                InvalidPreferencesWarning(
+                                PreferencesChangedWarning(
                                     f"{student} ranked {project} but its "
                                     "supervisor did not."
                                 )
@@ -472,7 +472,7 @@ class StudentAllocation(BaseGame):
             for project in supervisor.projects:
                 if project.capacity > supervisor.capacity:
                     warnings.warn(
-                        InvalidCapacityWarning(
+                        CapacityChangedWarning(
                             f"{project} has a capacity of {project.capacity} "
                             "but its supervisor has a capacity of "
                             f"{supervisor.capacity}."
@@ -493,7 +493,7 @@ class StudentAllocation(BaseGame):
 
             if supervisor.capacity > total_project_capacity:
                 warnings.warn(
-                    InvalidCapacityWarning(
+                    CapacityChangedWarning(
                         f"{supervisor} has a capacity of {supervisor.capacity} "
                         "but their projects have a capacity of "
                         f"{total_project_capacity}"

--- a/src/matching/player.py
+++ b/src/matching/player.py
@@ -23,6 +23,13 @@ class Player:
         The original set of player preferences.
     """
 
+    unmatched_message = lambda player: f"{player} is unmatched."
+
+    not_in_preferences_message = lambda player, other: (
+        f"{player} is matched to {other} but they do not appear in their "
+        f"preference list: {player.prefs}."
+    )
+
     def __init__(self, name):
 
         self.name = name
@@ -77,3 +84,15 @@ class Player:
 
         prefs = self._original_prefs
         return prefs.index(player) < prefs.index(other)
+
+    def check_if_match_is_unacceptable(self, unmatched_okay=False):
+        """ Check the acceptability of the current match, with the stipulation
+        that being unmatched is okay (or not). """
+
+        other = self.matching
+
+        if other is None and unmatched_okay is False:
+            return self.unmatched_message()
+
+        elif other is not None and other not in self.prefs:
+            return self.not_in_preferences_message(other)

--- a/src/matching/players/hospital.py
+++ b/src/matching/players/hospital.py
@@ -32,6 +32,11 @@ class Hospital(Player):
         unsubscribed.
     """
 
+    oversubscribed_message = lambda player: (
+        f"{player} is matched to {player.matching} which is over their "
+        f"capacity of {player.capacity}."
+    )
+
     def __init__(self, name, capacity):
 
         super().__init__(name)
@@ -73,3 +78,20 @@ class Hospital(Player):
 
         idx = self.prefs.index(self.get_worst_match())
         return self.prefs[idx + 1 :]
+
+    def check_if_match_is_unacceptable(self, **kwargs):
+        """ Check the acceptability of the current matches. """
+
+        issues = []
+        for other in self.matching:
+            if other not in self.prefs:
+                issues.append(self.not_in_preferences_message(other))
+
+        if issues:
+            return issues
+
+    def check_if_oversubscribed(self):
+        """ Check whether the player has too many matches. """
+
+        if len(self.matching) > self.capacity:
+            return self.oversubscribed_message()

--- a/tests/hospital_resident/params.py
+++ b/tests/hospital_resident/params.py
@@ -99,6 +99,8 @@ HOSPITAL_RESIDENT = given(
         max_size=3,
         unique=True,
     ),
-    capacities=lists(elements=integers(min_value=2), min_size=3, max_size=3),
+    capacities=lists(
+        elements=integers(min_value=2, max_value=4), min_size=3, max_size=3,
+    ),
     seed=integers(min_value=0, max_value=2 ** 32 - 1),
 )

--- a/tests/hospital_resident/test_solver.py
+++ b/tests/hospital_resident/test_solver.py
@@ -1,14 +1,13 @@
 """ Unit tests for the HR solver. """
-
 import warnings
 
 import pytest
 
 from matching import Matching
 from matching import Player as Resident
+from matching.exceptions import PlayerExcludedWarning, PreferencesChangedWarning
 from matching.games import HospitalResident
 from matching.players import Hospital
-from matching.warning import InvalidPreferencesWarning, PlayerExcludedWarning
 
 from .params import HOSPITAL_RESIDENT, make_game, make_prefs
 
@@ -86,7 +85,7 @@ def test_inputs_resident_prefs_all_hospitals(
         game._check_resident_prefs_all_hospitals()
 
         message = w[-1].message
-        assert isinstance(message, InvalidPreferencesWarning)
+        assert isinstance(message, PreferencesChangedWarning)
         assert resident.name in str(message)
         assert "foo" in str(message)
         assert resident.prefs == []
@@ -141,7 +140,7 @@ def test_inputs_hospital_prefs_all_reciprocate(
         game._check_hospital_prefs_all_reciprocated()
 
         message = w[-1].message
-        assert isinstance(message, InvalidPreferencesWarning)
+        assert isinstance(message, PreferencesChangedWarning)
         assert hospital.name in str(message)
         assert resident.name in str(message)
         assert resident not in hospital.prefs
@@ -170,7 +169,7 @@ def test_inputs_hospital_reciprocates_all_prefs(
         game._check_hospital_reciprocates_all_prefs()
 
         message = w[-1].message
-        assert isinstance(message, InvalidPreferencesWarning)
+        assert isinstance(message, PreferencesChangedWarning)
         assert hospital.name in str(message)
         assert resident.name in str(message)
         assert hospital not in resident.prefs

--- a/tests/hospital_resident/test_solver.py
+++ b/tests/hospital_resident/test_solver.py
@@ -5,7 +5,11 @@ import pytest
 
 from matching import Matching
 from matching import Player as Resident
-from matching.exceptions import PlayerExcludedWarning, PreferencesChangedWarning
+from matching.exceptions import (
+    MatchingError,
+    PlayerExcludedWarning,
+    PreferencesChangedWarning,
+)
 from matching.games import HospitalResident
 from matching.players import Hospital
 
@@ -274,45 +278,68 @@ def test_check_validity(resident_names, hospital_names, capacities, seed):
 
 
 @HOSPITAL_RESIDENT
-def test_resident_matching(resident_names, hospital_names, capacities, seed):
-    """ Test that HospitalResident recognises a valid matching requires a resident
-    to have a preference of their match, if they have one. """
+def test_check_for_unacceptable_matches_residents(
+    resident_names, hospital_names, capacities, seed
+):
+    """ Test that HospitalResident recognises a valid matching requires each
+    resident to have a preference of their match, if they have one. """
 
     _, _, game = make_game(resident_names, hospital_names, capacities, seed)
-
     game.solve()
-    game.residents[0].matching = Resident(name="foo")
 
-    with pytest.raises(Exception):
-        game._check_resident_matching()
+    resident = game.residents[0]
+    hospital = Hospital(name="foo", capacity="bar")
+    resident.matching = hospital
+
+    with pytest.raises(MatchingError) as e:
+        game.check_validity()
+        error = e.unacceptable_matches[0]
+        assert error.startswith(resident.name)
+        assert error.endswith(hospital.name)
+        assert str(resident.prefs) in error
 
 
 @HOSPITAL_RESIDENT
-def test_hospital_matching(resident_names, hospital_names, capacities, seed):
-    """ Test that HospitalResident recognises a valid matching requires a
+def test_check_for_unacceptable_matches_hospitals(
+    resident_names, hospital_names, capacities, seed
+):
+    """ Test that HospitalResident recognises a valid matching requires each
     hospital to have a preference of each of its matches, if any. """
 
     _, _, game = make_game(resident_names, hospital_names, capacities, seed)
-
     game.solve()
-    game.hospitals[0].matching.append(Resident(name="foo"))
 
-    with pytest.raises(Exception):
-        game._check_hospital_matching()
+    hospital = game.hospitals[0]
+    resident = Resident(name="foo")
+    hospital.matching.append(resident)
+
+    with pytest.raises(MatchingError) as e:
+        game.check_validity()
+        error = e.unacceptable_matches[0]
+        assert error.startswith(hospital.name)
+        assert error.endswith(resident.name)
+        assert str(hospital.prefs) in error
 
 
 @HOSPITAL_RESIDENT
-def test_hospital_capacity(resident_names, hospital_names, capacities, seed):
+def test_check_for_oversubscribed_hospitals(
+    resident_names, hospital_names, capacities, seed
+):
     """ Test that HospitalResident recognises a valid matching requires all
-    hospitals to not be over-subscribed. """
+    hospitals to not be oversubscribed. """
 
     _, _, game = make_game(resident_names, hospital_names, capacities, seed)
-
     game.solve()
-    game.hospitals[0].matching = range(game.hospitals[0].capacity + 1)
 
-    with pytest.raises(Exception):
-        game._check_hospital_capacity()
+    hospital = game.hospitals[0]
+    hospital.matching = range(hospital.capacity + 1)
+
+    with pytest.raises(MatchingError) as e:
+        game.check_validity()
+        error = e.oversubscribed_hospitals[0]
+        assert error.startswith(hospital.name)
+        assert error.endswith(str(hospital.capacity))
+        assert str(hospital.matching) in error
 
 
 def test_check_stability():

--- a/tests/players/test_hospital.py
+++ b/tests/players/test_hospital.py
@@ -96,3 +96,18 @@ def test_get_successors(name, capacity, pref_names):
 
     hospital.matching = others
     assert hospital.get_successors() == []
+
+
+@given(name=text(), capacity=integers(), pref_names=lists(text(), min_size=1))
+def test_check_if_match_is_unacceptable(name, capacity, pref_names):
+    """ Check that a hospital can verify the acceptability of its matches. """
+
+    hospital = Hospital(name, capacity)
+    others = [Resident(other) for other in pref_names]
+
+    assert hospital.check_if_match_is_unacceptable() is None
+
+    hospital.set_prefs(others[:-1])
+    hospital.matching = [others[-1]]
+    message = hospital.not_in_preferences_message(others[-1])
+    assert hospital.check_if_match_is_unacceptable() == [message]

--- a/tests/players/test_player.py
+++ b/tests/players/test_player.py
@@ -119,3 +119,22 @@ def test_prefers(name, pref_names):
     player.set_prefs(others)
     for i, other in enumerate(others[:-1]):
         assert player.prefers(other, others[i + 1])
+
+
+@given(name=text(), pref_names=lists(text(), min_size=1, unique=True))
+def test_check_if_match_unacceptable(name, pref_names):
+    """ Test that the acceptability of a match is caught correctly. """
+
+    player = Player(name)
+    others = [Player(other) for other in pref_names]
+
+    message = player.unmatched_message()
+    assert player.check_if_match_is_unacceptable() == message
+
+    player.set_prefs(others[:-1])
+    player.match(others[-1])
+    message = player.not_in_preferences_message(others[-1])
+    assert player.check_if_match_is_unacceptable() == message
+
+    player.set_prefs(others)
+    assert player.check_if_match_is_unacceptable() is None

--- a/tests/stable_roommates/test_solver.py
+++ b/tests/stable_roommates/test_solver.py
@@ -1,8 +1,8 @@
 """ Unit tests for the SR solver. """
-
 import pytest
 
 from matching import Matching
+from matching.exceptions import MatchingError
 from matching.games import StableRoommates
 
 from .params import STABLE_ROOMMATES, make_players, make_prefs
@@ -84,7 +84,7 @@ def test_check_validity(player_names, seed):
 
     matching = game.solve()
     if None in matching.values():
-        with pytest.raises(Exception):
+        with pytest.raises(MatchingError):
             game.check_validity()
 
     else:

--- a/tests/student_allocation/test_solver.py
+++ b/tests/student_allocation/test_solver.py
@@ -7,6 +7,7 @@ from matching import Matching
 from matching import Player as Student
 from matching.exceptions import (
     CapacityChangedWarning,
+    MatchingError,
     PlayerExcludedWarning,
     PreferencesChangedWarning,
 )
@@ -518,47 +519,55 @@ def test_check_validity(
 
 
 @STUDENT_ALLOCATION
-def test_check_student_matching(
+def test_check_for_unacceptable_matches_students(
     student_names, project_names, supervisor_names, capacities, seed
 ):
-    """ Test that StudentAllocation recognises a valid matching requires a
+    """ Test that StudentAllocation recognises a valid matching requires each
     student to have a preference of their match, if they have one. """
 
     _, _, _, game = make_game(
         student_names, project_names, supervisor_names, capacities, seed
     )
-
     game.solve()
-    assert game._check_student_matching()
 
     student = game.students[0]
-    student.matching = Project(name="foo", capacity=0)
-    with pytest.raises(Exception):
-        game._check_student_matching()
+    project = Project(name="foo", capacity=0)
+    student.matching = project
+
+    with pytest.raises(MatchingError) as e:
+        game.check_validity()
+        error = e.unacceptable_matches[0]
+        assert error.startswith(student.name)
+        assert error.endswith(str(student.prefs))
+        assert project.name in error
 
 
 @STUDENT_ALLOCATION
-def test_check_project_matching(
+def test_check_for_unacceptable_matches_projects(
     student_names, project_names, supervisor_names, capacities, seed
 ):
-    """ Test that StudentAllocation recognises a valid matching requires a
+    """ Test that StudentAllocation recognises a valid matching requires each
     project to have a preference of each of their matches, if they have any. """
 
     _, _, _, game = make_game(
         student_names, project_names, supervisor_names, capacities, seed
     )
-
     game.solve()
-    assert game._check_project_matching()
 
     project = game.projects[0]
-    project.matching.append(Student(name="foo"))
-    with pytest.raises(Exception):
-        game._check_project_matching()
+    student = Student(name="foo")
+    project.matching.append(student)
+
+    with pytest.raises(MatchingError) as e:
+        game.check_validity()
+        error = e.unacceptable_matches[0]
+        assert error.startswith(project.name)
+        assert error.endswith(str(project.prefs))
+        assert str(student.name) in error
 
 
 @STUDENT_ALLOCATION
-def test_check_supervisor_matching(
+def test_check_for_unacceptable_matches_supervisors(
     student_names, project_names, supervisor_names, capacities, seed
 ):
     """ Test that StudentAllocation recognises a valid matching requires each
@@ -568,18 +577,22 @@ def test_check_supervisor_matching(
     _, _, _, game = make_game(
         student_names, project_names, supervisor_names, capacities, seed
     )
-
     game.solve()
-    assert game._check_supervisor_matching()
 
     supervisor = game.supervisors[0]
-    supervisor.matching.append(Student(name="foo"))
-    with pytest.raises(Exception):
-        game._check_supervisor_matching()
+    student = Student(name="foo")
+    supervisor.matching.append(student)
+
+    with pytest.raises(MatchingError) as e:
+        game.check_validity()
+        error = e.unacceptable_matches[0]
+        assert error.startswith(supervisor.name)
+        assert error.endswith(str(supervisor.prefs))
+        assert student.name in error
 
 
 @STUDENT_ALLOCATION
-def test_check_project_capacity(
+def test_check_for_oversubscribed_projects(
     student_names, project_names, supervisor_names, capacities, seed
 ):
     """ Test that StudentAllocation recognises a valid matching requires all
@@ -588,18 +601,21 @@ def test_check_project_capacity(
     _, _, _, game = make_game(
         student_names, project_names, supervisor_names, capacities, seed
     )
-
     game.solve()
-    assert game._check_project_capacity()
 
     project = game.projects[0]
     project.matching = range(project.capacity + 1)
-    with pytest.raises(Exception):
-        game._check_project_capacity()
+
+    with pytest.raises(MatchingError) as e:
+        game.check_validity()
+        error = e.oversubscribed_players[0]
+        assert error.startswith(project.name)
+        assert error.endswith(str(project.capacity))
+        assert str(project.matching) in e
 
 
 @STUDENT_ALLOCATION
-def test_check_supervisor_capacity(
+def test_check_for_oversubscribed_supervisors(
     student_names, project_names, supervisor_names, capacities, seed
 ):
     """ Test that StudentAllocation recognises a valid matching requires all
@@ -608,14 +624,17 @@ def test_check_supervisor_capacity(
     _, _, _, game = make_game(
         student_names, project_names, supervisor_names, capacities, seed
     )
-
     game.solve()
-    assert game._check_supervisor_capacity()
 
     supervisor = game.supervisors[0]
     supervisor.matching = range(supervisor.capacity + 1)
-    with pytest.raises(Exception):
-        game._check_supervisor_capacity()
+
+    with pytest.raises(MatchingError) as e:
+        game.check_validity()
+        error = e.oversubscribed_players[0]
+        assert error.startswith(supervisor.name)
+        assert error.endswith(str(supervisor.capacity))
+        assert str(supervisor.matching) in e
 
 
 def test_check_stability():

--- a/tests/student_allocation/test_solver.py
+++ b/tests/student_allocation/test_solver.py
@@ -5,13 +5,13 @@ import pytest
 
 from matching import Matching
 from matching import Player as Student
+from matching.exceptions import (
+    CapacityChangedWarning,
+    PlayerExcludedWarning,
+    PreferencesChangedWarning,
+)
 from matching.games import StudentAllocation
 from matching.players import Project, Supervisor
-from matching.warning import (
-    InvalidCapacityWarning,
-    InvalidPreferencesWarning,
-    PlayerExcludedWarning,
-)
 
 from .params import STUDENT_ALLOCATION, make_connections, make_game
 
@@ -106,7 +106,7 @@ def test_inputs_student_prefs_all_projects(
         game._check_student_prefs_all_projects()
 
         message = w[-1].message
-        assert isinstance(message, InvalidPreferencesWarning)
+        assert isinstance(message, PreferencesChangedWarning)
         assert student.name in str(message)
         assert "foo" in str(message)
         assert student.prefs == []
@@ -165,7 +165,7 @@ def test_inputs_project_prefs_all_reciprocate(
         game._check_project_prefs_all_reciprocated()
 
         message = w[-1].message
-        assert isinstance(message, InvalidPreferencesWarning)
+        assert isinstance(message, PreferencesChangedWarning)
         assert project.name in str(message)
         assert student.name in str(message)
         assert student not in project.prefs
@@ -196,7 +196,7 @@ def test_inputs_project_reciprocates_all_prefs(
         game._check_project_reciprocates_all_prefs()
 
         message = w[-1].message
-        assert isinstance(message, InvalidPreferencesWarning)
+        assert isinstance(message, PreferencesChangedWarning)
         assert project.name in str(message)
         assert student.name in str(message)
         assert project not in student.prefs
@@ -260,7 +260,7 @@ def test_inputs_supervisor_prefs_all_reciprocate(
         game._check_supervisor_prefs_all_reciprocated()
 
         message = w[-1].message
-        assert isinstance(message, InvalidPreferencesWarning)
+        assert isinstance(message, PreferencesChangedWarning)
         assert supervisor.name in str(message)
         assert student.name in str(message)
         assert student not in supervisor.prefs
@@ -292,7 +292,7 @@ def test_inputs_supervisor_reciprocates_all_prefs(
 
         w, *ws = ws
         message = w.message
-        assert isinstance(message, InvalidPreferencesWarning)
+        assert isinstance(message, PreferencesChangedWarning)
         assert supervisor.name in str(message)
         assert student.name in str(message)
         assert supervisor not in student.prefs
@@ -427,7 +427,7 @@ def test_inputs_supervisor_capacities_sufficient(
         game._check_init_supervisor_capacities_sufficient()
 
         message = w[-1].message
-        assert isinstance(message, InvalidCapacityWarning)
+        assert isinstance(message, CapacityChangedWarning)
         assert project.name in str(message)
         assert str(supervisor_capacity) in str(message)
         assert project.capacity == supervisor_capacity
@@ -458,7 +458,7 @@ def test_inputs_supervisor_capacities_necessary(
         game._check_init_supervisor_capacities_necessary()
 
         message = w[-1].message
-        assert isinstance(message, InvalidCapacityWarning)
+        assert isinstance(message, CapacityChangedWarning)
         assert supervisor.name in str(message)
         assert str(total_project_capacity) in str(message)
         assert supervisor.capacity == total_project_capacity


### PR DESCRIPTION
This PR moves `matching.warning` to `matching.exceptions` and introduces the `MatchingError` exception for use in post-solve checks for validity.