### PR TITLE
Generalise post-solve checks

### DIFF
--- a/src/matching/exceptions.py
+++ b/src/matching/exceptions.py
@@ -3,6 +3,13 @@
 class MatchingError(Exception):
     """ A generic error for when something is wrong with an internal object. """
 
+    def __init__(self, unacceptables=[], oversubscribeds=[]):
+
+        self.unacceptables = unacceptables
+        self.oversubscribeds = oversubscribeds
+        self.message = [*unacceptables, *oversubscribeds]
+
+        super().__init__(self.message)
 
 class PreferencesChangedWarning(UserWarning):
     """ A warning for when the preferences of a player are invalid. """

--- a/src/matching/exceptions.py
+++ b/src/matching/exceptions.py
@@ -1,5 +1,6 @@
 """ Exceptions for game solver checks. """
 
+
 class MatchingError(Exception):
     """ A generic error for when something is wrong with an internal object. """
 
@@ -11,6 +12,7 @@ class MatchingError(Exception):
         self.message = kwargs
 
         super().__init__(self.message)
+
 
 class PreferencesChangedWarning(UserWarning):
     """ A warning for when the preferences of a player are invalid. """

--- a/src/matching/exceptions.py
+++ b/src/matching/exceptions.py
@@ -3,11 +3,12 @@
 class MatchingError(Exception):
     """ A generic error for when something is wrong with an internal object. """
 
-    def __init__(self, unacceptables=[], oversubscribeds=[]):
+    def __init__(self, **kwargs):
 
-        self.unacceptables = unacceptables
-        self.oversubscribeds = oversubscribeds
-        self.message = [*unacceptables, *oversubscribeds]
+        for key, val in kwargs.items():
+            self.__setattr__(key, val)
+
+        self.message = kwargs
 
         super().__init__(self.message)
 

--- a/src/matching/games/hospital_resident.py
+++ b/src/matching/games/hospital_resident.py
@@ -102,23 +102,11 @@ class HospitalResident(BaseGame):
         """ Check that no player in `party` is matched to an unacceptable
         player. """
 
-        message = lambda player, other: (
-            f"{player} is matched to {other} but they do not appear in their "
-            f"preference list: {player.prefs}."
-        )
-
         issues = []
         for player in vars(self)[party]:
-
-            try:
-                for other in player.matching:
-                    if other not in player.prefs:
-                        issues.append(message(player, other))
-
-            except TypeError:
-                other = player.matching
-                if other is not None and other not in player.prefs:
-                    issues.append(message(player, other))
+            issue = player.check_if_match_is_unacceptable(unmatched_okay=True)
+            if issue:
+                issues.append(issue)
 
         return issues
 
@@ -127,11 +115,9 @@ class HospitalResident(BaseGame):
 
         issues = []
         for player in vars(self)[party]:
-            if len(player.matching) > player.capacity:
-                issues.append(
-                    f"{player} is matched to {player.matching} which is over "
-                    f"their capacity of {player.capacity}."
-                )
+            issue = player.check_if_oversubscribed()
+            if issue:
+                issues.append(issue)
 
         return issues
 

--- a/src/matching/games/hospital_resident.py
+++ b/src/matching/games/hospital_resident.py
@@ -175,6 +175,42 @@ class HospitalResident(BaseGame):
         self._check_hospital_prefs_all_nonempty()
         self._check_init_hospital_capacities()
 
+    def _check_for_unacceptable_matchings(self, party):
+        """ Check that no player in `party` is matched to an unacceptable
+        player. """
+
+        message = lambda player, other: (
+            f"{player} is matched to {other} but they do not appear in their "
+            f"preference list: {player.prefs}."
+        )
+        errors = []
+        for player in vars(self)[party]:
+
+            try:
+                for other in player.matching:
+                    if other not in player.prefs:
+                        errors.append(message(player, other))
+
+            except TypeError:
+                other = player.matching
+                if other is not None and other not in player.prefs:
+                    errors.append(message(player, other))
+
+        return errors
+
+    def _check_for_oversubscribed_players(self, party):
+        """ Check that no player in `party` is oversubscribed. """
+
+        errors = []
+        for player in vars(self)[party]:
+            if len(player.matching) > player.capacity:
+                errors.append(
+                    f"{player} is matched to {player.matching} which is over "
+                    f"their capacity of {player.capacity}."
+                )
+
+        return errors
+
     def _check_resident_prefs_all_hospitals(self):
         """ Make sure that each resident has ranked only hospitals. """
 

--- a/src/matching/games/hospital_resident.py
+++ b/src/matching/games/hospital_resident.py
@@ -4,7 +4,11 @@ import warnings
 
 from matching import BaseGame, Matching
 from matching import Player as Resident
-from matching.exceptions import MatchingError, PlayerExcludedWarning, PreferencesChangedWarning
+from matching.exceptions import (
+    MatchingError,
+    PlayerExcludedWarning,
+    PreferencesChangedWarning,
+)
 from matching.players import Hospital
 
 from .util import delete_pair, match_pair
@@ -81,10 +85,9 @@ class HospitalResident(BaseGame):
     def check_validity(self):
         """ Check whether the current matching is valid. """
 
-        unacceptable_issues = (
-            self._check_for_unacceptable_matches("residents")
-            + self._check_for_unacceptable_matches("hospitals")
-        )
+        unacceptable_issues = self._check_for_unacceptable_matches(
+            "residents"
+        ) + self._check_for_unacceptable_matches("hospitals")
 
         oversubscribed_issues = self._check_for_oversubscribed_players(
             "hospitals"
@@ -148,7 +151,6 @@ class HospitalResident(BaseGame):
         self._check_hospital_reciprocates_all_prefs()
         self._check_hospital_prefs_all_nonempty()
         self._check_init_hospital_capacities()
-
 
     def _check_resident_prefs_all_hospitals(self):
         """ Make sure that each resident has ranked only hospitals. """

--- a/src/matching/games/hospital_resident.py
+++ b/src/matching/games/hospital_resident.py
@@ -81,16 +81,19 @@ class HospitalResident(BaseGame):
     def check_validity(self):
         """ Check whether the current matching is valid. """
 
-        unacceptables = (
+        unacceptable_issues = (
             self._check_for_unacceptable_matches("residents")
             + self._check_for_unacceptable_matches("hospitals")
         )
-        oversubs = self._check_for_oversubscribed_players("hospitals")
 
-        if unacceptables or oversubs:
+        oversubscribed_issues = self._check_for_oversubscribed_players(
+            "hospitals"
+        )
+
+        if unacceptable_issues or oversubscribed_issues:
             raise MatchingError(
-                unacceptable_matches=unacceptables,
-                oversubscribed_hospitals=oversubs,
+                unacceptable_matches=unacceptable_issues,
+                oversubscribed_hospitals=oversubscribed_issues,
             )
 
         return True
@@ -103,33 +106,34 @@ class HospitalResident(BaseGame):
             f"{player} is matched to {other} but they do not appear in their "
             f"preference list: {player.prefs}."
         )
-        errors = []
+
+        issues = []
         for player in vars(self)[party]:
 
             try:
                 for other in player.matching:
                     if other not in player.prefs:
-                        errors.append(message(player, other))
+                        issues.append(message(player, other))
 
             except TypeError:
                 other = player.matching
                 if other is not None and other not in player.prefs:
-                    errors.append(message(player, other))
+                    issues.append(message(player, other))
 
-        return errors
+        return issues
 
     def _check_for_oversubscribed_players(self, party):
         """ Check that no player in `party` is oversubscribed. """
 
-        errors = []
+        issues = []
         for player in vars(self)[party]:
             if len(player.matching) > player.capacity:
-                errors.append(
+                issues.append(
                     f"{player} is matched to {player.matching} which is over "
                     f"their capacity of {player.capacity}."
                 )
 
-        return errors
+        return issues
 
     def check_stability(self):
         """ Check for the existence of any blocking pairs in the current

--- a/src/matching/games/stable_marriage.py
+++ b/src/matching/games/stable_marriage.py
@@ -3,6 +3,7 @@
 import copy
 
 from matching import BaseGame, Matching, Player
+from matching.exceptions import MatchingError
 
 from .util import delete_pair, match_pair
 
@@ -57,7 +58,23 @@ class StableMarriage(BaseGame):
         )
         return self.matching
 
-    def check_stability(self):
+     def check_validity(self):
+        """ Check whether the current matching is valid. """
+
+        unmatched_issues = self._check_for_unmatched_players()
+        not_in_matching_issues = self._check_for_players_not_in_matching()
+        inconsistency_issues = self._check_for_inconsistent_matches()
+
+        if unmatched_issues or not_in_matching_issues or inconsistency_issues:
+            raise MatchingError(
+                unmatched_players=unmatched_issues,
+                players_not_in_matching=not_in_matching_issues,
+                inconsistent_matches=inconsistency_issues,
+            )
+
+        return True
+
+   def check_stability(self):
         """ Check for the existence of any blocking pairs in the current
         matching, thus determining the stability of the matching. """
 
@@ -72,60 +89,44 @@ class StableMarriage(BaseGame):
         self.blocking_pairs = blocking_pairs
         return not any(blocking_pairs)
 
-    def check_validity(self):
-        """ Check whether the current matching is valid. """
-
-        self._check_all_matched()
-        self._check_matching_consistent()
-        return True
-
-    def _check_all_matched(self):
+    def _check_for_unmatched_players(self):
         """ Check everyone has a match. """
 
-        errors = []
+        issues = []
         for player in self.suitors + self.reviewers:
             if player.matching is None:
-                errors.append(ValueError(f"{player} is unmatched."))
-            if player not in list(self.matching.keys()) + list(
-                self.matching.values()
-            ):
-                errors.append(
-                    ValueError(f"{player} does not appear in matching.")
-                )
+                issues.append(f"{player} is unmatched.")
 
-        if errors:
-            raise Exception(*errors)
+        return issues
 
-        return True
+    def _check_for_players_not_in_matching(self):
+        """ Check that everyone appears in the matching. """
 
-    def _check_matching_consistent(self):
-        """ Check that the game matching is consistent with the players. """
+        players_in_matching = (
+            set(self.matching.keys()) | set(self.matching.values())
+        )
 
-        errors = []
+        issues = []
+        for player in self.suitors + self.reviewers:
+            if player not in players_in_matching:
+                issues.append(f"{player} does not appear in matching.")
+
+        return issues
+
+    def _check_for_inconsistent_matches(self):
+        """ Check that the game matching is consistent with those of the
+        players. """
+
+        issues = []
         matching = self.matching
-        for suitor in self.suitors:
-            if suitor.matching != matching[suitor]:
-                errors.append(
-                    ValueError(
-                        f"{suitor} is matched to {suitor.matching} but matching"
-                        f" says {matching[suitor]}."
-                    )
+        for suitor, reviewer in self.matching.items():
+            if suitor.matching != reviewer:
+                issues.append(
+                    f"{suitor} is matched to {suitor.matching} but the "
+                    f"matching says they should be matched to {reviewer}."
                 )
 
-        for reviewer in self.reviewers:
-            suitor = [s for s in matching if matching[s] == reviewer][0]
-            if reviewer.matching != suitor:
-                errors.append(
-                    ValueError(
-                        f"{reviewer} is matched to {reviewer.matching} but "
-                        f"matching says {suitor}."
-                    )
-                )
-
-        if errors:
-            raise Exception(*errors)
-
-        return True
+        return issues
 
     def _check_inputs(self):
         """ Raise an error if any of the conditions of the game have been

--- a/src/matching/games/stable_marriage.py
+++ b/src/matching/games/stable_marriage.py
@@ -103,8 +103,8 @@ class StableMarriage(BaseGame):
     def _check_for_players_not_in_matching(self):
         """ Check that everyone appears in the matching. """
 
-        players_in_matching = (
-            set(self.matching.keys()) | set(self.matching.values())
+        players_in_matching = set(self.matching.keys()) | set(
+            self.matching.values()
         )
 
         issues = []

--- a/src/matching/games/stable_marriage.py
+++ b/src/matching/games/stable_marriage.py
@@ -58,7 +58,7 @@ class StableMarriage(BaseGame):
         )
         return self.matching
 
-     def check_validity(self):
+    def check_validity(self):
         """ Check whether the current matching is valid. """
 
         unmatched_issues = self._check_for_unmatched_players()
@@ -74,7 +74,7 @@ class StableMarriage(BaseGame):
 
         return True
 
-   def check_stability(self):
+    def check_stability(self):
         """ Check for the existence of any blocking pairs in the current
         matching, thus determining the stability of the matching. """
 
@@ -94,8 +94,9 @@ class StableMarriage(BaseGame):
 
         issues = []
         for player in self.suitors + self.reviewers:
-            if player.matching is None:
-                issues.append(f"{player} is unmatched.")
+            issue = player.check_if_match_is_unacceptable(unmatched_okay=False)
+            if issue:
+                issues.append(issue)
 
         return issues
 

--- a/src/matching/games/stable_roommates.py
+++ b/src/matching/games/stable_roommates.py
@@ -3,6 +3,7 @@
 import copy
 
 from matching import BaseGame, Matching, Player
+from matching.exceptions import MatchingError
 
 from .util import delete_pair, match_pair
 
@@ -46,6 +47,20 @@ class StableRoommates(BaseGame):
         self.matching = Matching(stable_roommates(self.players))
         return self.matching
 
+    def check_validity(self):
+        """ Check whether the current matching is valid. Raise `MatchingError`
+        detailing the issues if not. """
+
+        issues = []
+        for player in self.players:
+            if player.matching is None:
+                issues.append(f"{player} is unmatched.")
+
+        if issues:
+            raise MatchingError(unmatched_players=issues)
+
+        return True
+
     def check_stability(self):
         """ Check for the existence of any blocking pairs in the current
         matching. Then the stability of the matching holds when there are no
@@ -68,19 +83,6 @@ class StableRoommates(BaseGame):
 
         self.blocking_pairs = blocking_pairs
         return not any(blocking_pairs)
-
-    def check_validity(self):
-        """ Check whether the current matching is valid. """
-
-        errors = []
-        matching = self.matching
-        for player in self.players:
-            if player.matching is None:
-                errors.append(ValueError(f"{player} is unmatched."))
-        if errors:
-            raise Exception(*errors)
-
-        return True
 
     def _check_inputs(self):
         """ Check that all players have ranked all other players. """

--- a/src/matching/games/stable_roommates.py
+++ b/src/matching/games/stable_roommates.py
@@ -53,8 +53,9 @@ class StableRoommates(BaseGame):
 
         issues = []
         for player in self.players:
-            if player.matching is None:
-                issues.append(f"{player} is unmatched.")
+            issue = player.check_if_match_is_unacceptable(unmatched_okay=False)
+            if issue:
+                issues.append(issue)
 
         if issues:
             raise MatchingError(unmatched_players=issues)

--- a/src/matching/games/student_allocation.py
+++ b/src/matching/games/student_allocation.py
@@ -129,20 +129,21 @@ class StudentAllocation(HospitalResident):
         """ Check whether the current matching is valid. Raise a `MatchingError`
         detailing the issues if not. """
 
-        unacceptables = (
+        unacceptable_issues = (
             self._check_for_unacceptable_matches("students")
             + self._check_for_unacceptable_matches("projects")
             + self._check_for_unacceptable_matches("supervisors")
         )
-        oversubs = (
+
+        oversubscribed_issues = (
             self._check_for_oversubscribed_players("projects")
             + self._check_for_oversubscribed_players("supervisors")
         )
 
-        if unacceptables or oversubs:
+        if unacceptable_issues or oversubscribed_issues:
             raise MatchingError(
-                unacceptable_matches=unacceptables,
-                oversubscribed_players=oversubs,
+                unacceptable_matches=unacceptable_issues,
+                oversubscribed_players=oversubscribed_issues,
             )
 
         return True

--- a/src/matching/games/student_allocation.py
+++ b/src/matching/games/student_allocation.py
@@ -130,17 +130,20 @@ class StudentAllocation(HospitalResident):
         detailing the issues if not. """
 
         unacceptables = (
-            self._check_for_unacceptable_matchings("students")
-            + self._check_for_unacceptable_matchings("projects")
-            + self._check_for_unacceptable_matchings("supervisors")
+            self._check_for_unacceptable_matches("students")
+            + self._check_for_unacceptable_matches("projects")
+            + self._check_for_unacceptable_matches("supervisors")
         )
-        oversubscribeds = (
+        oversubs = (
             self._check_for_oversubscribed_players("projects")
             + self._check_for_oversubscribed_players("supervisors")
         )
 
-        if unacceptables or oversubscribeds:
-            raise MatchingError(unacceptables, oversubscribeds)
+        if unacceptables or oversubs:
+            raise MatchingError(
+                unacceptable_matches=unacceptables,
+                oversubscribed_players=oversubs,
+            )
 
         return True
 

--- a/src/matching/games/student_allocation.py
+++ b/src/matching/games/student_allocation.py
@@ -2,8 +2,9 @@
 import copy
 import warnings
 
-from matching import BaseGame, Matching
+from matching import Matching
 from matching import Player as Student
+from matching.games import HospitalResident
 from matching.exceptions import (
     CapacityChangedWarning,
     MatchingError,
@@ -15,7 +16,7 @@ from matching.players import Project, Supervisor
 from .util import delete_pair, match_pair
 
 
-class StudentAllocation(BaseGame):
+class StudentAllocation(HospitalResident):
     """ A class for solving instances of the student-allocation problem (SA)
     using an adapted Gale-Shapley algorithm.
 
@@ -72,7 +73,7 @@ class StudentAllocation(BaseGame):
         self._all_projects = projects
         self._all_supervisors = supervisors
 
-        super().__init__()
+        super().__init__(students, projects)
         self._check_inputs()
 
     def _remove_player(self, player, player_party, other_party=None):

--- a/src/matching/games/student_allocation.py
+++ b/src/matching/games/student_allocation.py
@@ -4,13 +4,13 @@ import warnings
 
 from matching import Matching
 from matching import Player as Student
-from matching.games import HospitalResident
 from matching.exceptions import (
     CapacityChangedWarning,
     MatchingError,
     PlayerExcludedWarning,
     PreferencesChangedWarning,
 )
+from matching.games import HospitalResident
 from matching.players import Project, Supervisor
 
 from .util import delete_pair, match_pair
@@ -135,10 +135,9 @@ class StudentAllocation(HospitalResident):
             + self._check_for_unacceptable_matches("supervisors")
         )
 
-        oversubscribed_issues = (
-            self._check_for_oversubscribed_players("projects")
-            + self._check_for_oversubscribed_players("supervisors")
-        )
+        oversubscribed_issues = self._check_for_oversubscribed_players(
+            "projects"
+        ) + self._check_for_oversubscribed_players("supervisors")
 
         if unacceptable_issues or oversubscribed_issues:
             raise MatchingError(

--- a/src/matching/player.py
+++ b/src/matching/player.py
@@ -23,6 +23,13 @@ class Player:
         The original set of player preferences.
     """
 
+    unmatched_message = lambda player: f"{player} is unmatched."
+
+    not_in_preferences_message = lambda player, other: (
+        f"{player} is matched to {other} but they do not appear in their "
+        f"preference list: {player.prefs}."
+    )
+
     def __init__(self, name):
 
         self.name = name
@@ -77,3 +84,15 @@ class Player:
 
         prefs = self._original_prefs
         return prefs.index(player) < prefs.index(other)
+
+    def check_if_match_is_unacceptable(self, unmatched_okay=False):
+        """ Check the acceptability of the current match, with the stipulation
+        that being unmatched is okay (or not). """
+
+        other = self.matching
+
+        if other is None and unmatched_okay is False:
+            return self.unmatched_message()
+
+        elif other is not None and other not in self.prefs:
+            return self.not_in_preferences_message(other)

--- a/src/matching/players/hospital.py
+++ b/src/matching/players/hospital.py
@@ -32,6 +32,11 @@ class Hospital(Player):
         unsubscribed.
     """
 
+    oversubscribed_message = lambda player: (
+        f"{player} is matched to {player.matching} which is over their "
+        f"capacity of {player.capacity}."
+    )
+
     def __init__(self, name, capacity):
 
         super().__init__(name)
@@ -73,3 +78,20 @@ class Hospital(Player):
 
         idx = self.prefs.index(self.get_worst_match())
         return self.prefs[idx + 1 :]
+
+    def check_if_match_is_unacceptable(self, **kwargs):
+        """ Check the acceptability of the current matches. """
+
+        issues = []
+        for other in self.matching:
+            if other not in self.prefs:
+                issues.append(self.not_in_preferences_message(other))
+
+        if issues:
+            return issues
+
+    def check_if_oversubscribed(self):
+        """ Check whether the player has too many matches. """
+
+        if len(self.matching) > self.capacity:
+            return self.oversubscribed_message()

--- a/tests/hospital_resident/params.py
+++ b/tests/hospital_resident/params.py
@@ -99,6 +99,10 @@ HOSPITAL_RESIDENT = given(
         max_size=3,
         unique=True,
     ),
-    capacities=lists(elements=integers(min_value=2), min_size=3, max_size=3),
+    capacities=lists(
+        elements=integers(min_value=2, max_value=4),
+        min_size=3,
+        max_size=3,
+    ),
     seed=integers(min_value=0, max_value=2 ** 32 - 1),
 )

--- a/tests/hospital_resident/params.py
+++ b/tests/hospital_resident/params.py
@@ -100,9 +100,7 @@ HOSPITAL_RESIDENT = given(
         unique=True,
     ),
     capacities=lists(
-        elements=integers(min_value=2, max_value=4),
-        min_size=3,
-        max_size=3,
+        elements=integers(min_value=2, max_value=4), min_size=3, max_size=3,
     ),
     seed=integers(min_value=0, max_value=2 ** 32 - 1),
 )

--- a/tests/hospital_resident/test_solver.py
+++ b/tests/hospital_resident/test_solver.py
@@ -287,10 +287,10 @@ def test_check_for_unacceptable_matches_residents(resident_names, hospital_names
 
     with pytest.raises(MatchingError) as e:
         game.check_validity()
-        unacceptable_match = e.unacceptable_matches[0]
-        assert unacceptable_match.startswith(resident.name)
-        assert unacceptable_match.endswith(hospital.name)
-        assert str(resident.prefs)
+        error = e.unacceptable_matches[0]
+        assert error.startswith(resident.name)
+        assert error.endswith(hospital.name)
+        assert str(resident.prefs) in error
 
 
 @HOSPITAL_RESIDENT
@@ -307,10 +307,10 @@ def test_check_for_unacceptable_matches_hospitals(resident_names, hospital_names
 
     with pytest.raises(MatchingError) as e:
         game.check_validity()
-        unacceptable_match = e.unacceptable_matches[0]
-        assert unacceptable_match.startswith(hospital.name)
-        assert unacceptable_match.endswith(resident.name)
-        assert str(hospital.prefs) in unacceptable_match
+        error = e.unacceptable_matches[0]
+        assert error.startswith(hospital.name)
+        assert error.endswith(resident.name)
+        assert str(hospital.prefs) in error
 
 
 @HOSPITAL_RESIDENT
@@ -326,10 +326,10 @@ def test_check_for_oversubscribed_hospitals(resident_names, hospital_names, capa
 
     with pytest.raises(MatchingError) as e:
         game.check_validity()
-        oversubscribed_hospital = e.oversubscribed_hospitals[0]
-        assert oversubscribed_hospital.startswith(hospital.name)
-        assert oversubscribed_hospital.endswith(str(hospital.capacity))
-        assert str(hospital.matching) in oversubscribed_hospital
+        error = e.oversubscribed_hospitals[0]
+        assert error.startswith(hospital.name)
+        assert error.endswith(str(hospital.capacity))
+        assert str(hospital.matching) in error
 
 
 def test_check_stability():

--- a/tests/hospital_resident/test_solver.py
+++ b/tests/hospital_resident/test_solver.py
@@ -5,7 +5,7 @@ import pytest
 
 from matching import Matching
 from matching import Player as Resident
-from matching.exceptions import PlayerExcludedWarning, PreferencesChangedWarning
+from matching.exceptions import MatchingError, PlayerExcludedWarning, PreferencesChangedWarning
 from matching.games import HospitalResident
 from matching.players import Hospital
 
@@ -274,45 +274,62 @@ def test_check_validity(resident_names, hospital_names, capacities, seed):
 
 
 @HOSPITAL_RESIDENT
-def test_resident_matching(resident_names, hospital_names, capacities, seed):
-    """ Test that HospitalResident recognises a valid matching requires a resident
-    to have a preference of their match, if they have one. """
+def test_check_for_unacceptable_matches_residents(resident_names, hospital_names, capacities, seed):
+    """ Test that HospitalResident recognises a valid matching requires each
+    resident to have a preference of their match, if they have one. """
 
     _, _, game = make_game(resident_names, hospital_names, capacities, seed)
-
     game.solve()
-    game.residents[0].matching = Resident(name="foo")
 
-    with pytest.raises(Exception):
-        game._check_resident_matching()
+    resident = game.residents[0]
+    hospital = Hospital(name="foo", capacity="bar")
+    resident.matching = hospital
+
+    with pytest.raises(MatchingError) as e:
+        game.check_validity()
+        unacceptable_match = e.unacceptable_matches[0]
+        assert unacceptable_match.startswith(resident.name)
+        assert unacceptable_match.endswith(hospital.name)
+        assert str(resident.prefs)
 
 
 @HOSPITAL_RESIDENT
-def test_hospital_matching(resident_names, hospital_names, capacities, seed):
-    """ Test that HospitalResident recognises a valid matching requires a
+def test_check_for_unacceptable_matches_hospitals(resident_names, hospital_names, capacities, seed):
+    """ Test that HospitalResident recognises a valid matching requires each
     hospital to have a preference of each of its matches, if any. """
 
     _, _, game = make_game(resident_names, hospital_names, capacities, seed)
-
     game.solve()
-    game.hospitals[0].matching.append(Resident(name="foo"))
 
-    with pytest.raises(Exception):
-        game._check_hospital_matching()
+    hospital = game.hospitals[0]
+    resident = Resident(name="foo")
+    hospital.matching.append(resident)
+
+    with pytest.raises(MatchingError) as e:
+        game.check_validity()
+        unacceptable_match = e.unacceptable_matches[0]
+        assert unacceptable_match.startswith(hospital.name)
+        assert unacceptable_match.endswith(resident.name)
+        assert str(hospital.prefs) in unacceptable_match
 
 
 @HOSPITAL_RESIDENT
-def test_hospital_capacity(resident_names, hospital_names, capacities, seed):
+def test_check_for_oversubscribed_hospitals(resident_names, hospital_names, capacities, seed):
     """ Test that HospitalResident recognises a valid matching requires all
-    hospitals to not be over-subscribed. """
+    hospitals to not be oversubscribed. """
 
     _, _, game = make_game(resident_names, hospital_names, capacities, seed)
-
     game.solve()
-    game.hospitals[0].matching = range(game.hospitals[0].capacity + 1)
+    
+    hospital = game.hospitals[0]
+    hospital.matching = range(hospital.capacity + 1)
 
-    with pytest.raises(Exception):
-        game._check_hospital_capacity()
+    with pytest.raises(MatchingError) as e:
+        game.check_validity()
+        oversubscribed_hospital = e.oversubscribed_hospitals[0]
+        assert oversubscribed_hospital.startswith(hospital.name)
+        assert oversubscribed_hospital.endswith(str(hospital.capacity))
+        assert str(hospital.matching) in oversubscribed_hospital
 
 
 def test_check_stability():

--- a/tests/hospital_resident/test_solver.py
+++ b/tests/hospital_resident/test_solver.py
@@ -5,7 +5,11 @@ import pytest
 
 from matching import Matching
 from matching import Player as Resident
-from matching.exceptions import MatchingError, PlayerExcludedWarning, PreferencesChangedWarning
+from matching.exceptions import (
+    MatchingError,
+    PlayerExcludedWarning,
+    PreferencesChangedWarning,
+)
 from matching.games import HospitalResident
 from matching.players import Hospital
 
@@ -274,7 +278,9 @@ def test_check_validity(resident_names, hospital_names, capacities, seed):
 
 
 @HOSPITAL_RESIDENT
-def test_check_for_unacceptable_matches_residents(resident_names, hospital_names, capacities, seed):
+def test_check_for_unacceptable_matches_residents(
+    resident_names, hospital_names, capacities, seed
+):
     """ Test that HospitalResident recognises a valid matching requires each
     resident to have a preference of their match, if they have one. """
 
@@ -294,7 +300,9 @@ def test_check_for_unacceptable_matches_residents(resident_names, hospital_names
 
 
 @HOSPITAL_RESIDENT
-def test_check_for_unacceptable_matches_hospitals(resident_names, hospital_names, capacities, seed):
+def test_check_for_unacceptable_matches_hospitals(
+    resident_names, hospital_names, capacities, seed
+):
     """ Test that HospitalResident recognises a valid matching requires each
     hospital to have a preference of each of its matches, if any. """
 
@@ -314,13 +322,15 @@ def test_check_for_unacceptable_matches_hospitals(resident_names, hospital_names
 
 
 @HOSPITAL_RESIDENT
-def test_check_for_oversubscribed_hospitals(resident_names, hospital_names, capacities, seed):
+def test_check_for_oversubscribed_hospitals(
+    resident_names, hospital_names, capacities, seed
+):
     """ Test that HospitalResident recognises a valid matching requires all
     hospitals to not be oversubscribed. """
 
     _, _, game = make_game(resident_names, hospital_names, capacities, seed)
     game.solve()
-    
+
     hospital = game.hospitals[0]
     hospital.matching = range(hospital.capacity + 1)
 

--- a/tests/players/test_hospital.py
+++ b/tests/players/test_hospital.py
@@ -96,3 +96,18 @@ def test_get_successors(name, capacity, pref_names):
 
     hospital.matching = others
     assert hospital.get_successors() == []
+
+
+@given(name=text(), capacity=integers(), pref_names=lists(text(), min_size=1))
+def test_check_if_match_is_unacceptable(name, capacity, pref_names):
+    """ Check that a hospital can verify the acceptability of its matches. """
+
+    hospital = Hospital(name, capacity)
+    others = [Resident(other) for other in pref_names]
+
+    assert hospital.check_if_match_is_unacceptable() is None
+
+    hospital.set_prefs(others[:-1])
+    hospital.matching = [others[-1]]
+    message = hospital.not_in_preferences_message(others[-1])
+    assert hospital.check_if_match_is_unacceptable() == [message]

--- a/tests/players/test_player.py
+++ b/tests/players/test_player.py
@@ -59,7 +59,7 @@ def test_match(name, pref_names):
     other = Player(pref_names[0])
 
     player.match(other)
-    assert player.matching == other
+    assert player.matching == other 
 
 
 @given(name=text(), pref_names=lists(text(), min_size=1))
@@ -119,3 +119,22 @@ def test_prefers(name, pref_names):
     player.set_prefs(others)
     for i, other in enumerate(others[:-1]):
         assert player.prefers(other, others[i + 1])
+
+
+@given(name=text(), pref_names=lists(text(), min_size=1, unique=True))
+def test_check_if_match_unacceptable(name, pref_names):
+    """ Test that the acceptability of a match is caught correctly. """
+
+    player = Player(name)
+    others = [Player(other) for other in pref_names]
+
+    message = player.unmatched_message()
+    assert player.check_if_match_is_unacceptable() == message
+
+    player.set_prefs(others[:-1])
+    player.match(others[-1])
+    message = player.not_in_preferences_message(others[-1])
+    assert player.check_if_match_is_unacceptable() == message
+
+    player.set_prefs(others)
+    assert player.check_if_match_is_unacceptable() is None

--- a/tests/players/test_player.py
+++ b/tests/players/test_player.py
@@ -59,7 +59,7 @@ def test_match(name, pref_names):
     other = Player(pref_names[0])
 
     player.match(other)
-    assert player.matching == other 
+    assert player.matching == other
 
 
 @given(name=text(), pref_names=lists(text(), min_size=1))

--- a/tests/stable_marriage/test_solver.py
+++ b/tests/stable_marriage/test_solver.py
@@ -1,10 +1,9 @@
 """ Unit tests for the SM solver. """
-
 import pytest
 
 from matching import Matching
-from matching.games import StableMarriage
 from matching.exceptions import MatchingError
+from matching.games import StableMarriage
 
 from .params import STABLE_MARRIAGE, make_players, make_prefs
 

--- a/tests/stable_marriage/test_solver.py
+++ b/tests/stable_marriage/test_solver.py
@@ -4,6 +4,7 @@ import pytest
 
 from matching import Matching
 from matching.games import StableMarriage
+from matching.exceptions import MatchingError
 
 from .params import STABLE_MARRIAGE, make_players, make_prefs
 
@@ -119,19 +120,39 @@ def test_check_validity(player_names, seed):
 
 
 @STABLE_MARRIAGE
-def test_all_matched(player_names, seed):
+def test_check_for_unmatched_players(player_names, seed):
     """ Test that StableMarriage recognises a valid matching requires all
-    players to be matched as players and as part of the game. """
+    players to be matched as players. """
 
     suitors, reviewers = make_players(player_names, seed)
     game = StableMarriage(suitors, reviewers)
+    game.solve()
 
+    player = game.suitors[0]
+    player.matching = None
+
+    with pytest.raises(MatchingError) as e:
+        game.check_validity()
+        error = e.unmatched_players[0]
+        assert error.startswith(player.name)
+
+
+@STABLE_MARRIAGE
+def test_check_for_players_not_in_matching(player_names, seed):
+    """ Test that StableMarriage recognises a valid matching requires all
+    players to be matched in the matching. """
+
+    suitors, reviewers = make_players(player_names, seed)
+    game = StableMarriage(suitors, reviewers)
     matching = game.solve()
-    matching[game.suitors[0]].matching = None
-    game.matching[game.suitors[0]] = None
 
-    with pytest.raises(Exception):
-        game._check_all_matched()
+    player = game.suitors[0]
+    matching[player] = None
+
+    with pytest.raises(MatchingError) as e:
+        game.check_validity()
+        error = e.players[0]
+        assert error.startswith(player.name)
 
 
 @STABLE_MARRIAGE

--- a/tests/stable_roommates/test_solver.py
+++ b/tests/stable_roommates/test_solver.py
@@ -4,6 +4,7 @@ import pytest
 
 from matching import Matching
 from matching.games import StableRoommates
+from matching.exceptions import MatchingError
 
 from .params import STABLE_ROOMMATES, make_players, make_prefs
 
@@ -84,7 +85,7 @@ def test_check_validity(player_names, seed):
 
     matching = game.solve()
     if None in matching.values():
-        with pytest.raises(Exception):
+        with pytest.raises(MatchingError):
             game.check_validity()
 
     else:

--- a/tests/stable_roommates/test_solver.py
+++ b/tests/stable_roommates/test_solver.py
@@ -1,10 +1,9 @@
 """ Unit tests for the SR solver. """
-
 import pytest
 
 from matching import Matching
-from matching.games import StableRoommates
 from matching.exceptions import MatchingError
+from matching.games import StableRoommates
 
 from .params import STABLE_ROOMMATES, make_players, make_prefs
 

--- a/tests/student_allocation/test_solver.py
+++ b/tests/student_allocation/test_solver.py
@@ -528,18 +528,18 @@ def test_check_for_unacceptable_matchings_students(
     _, _, _, game = make_game(
         student_names, project_names, supervisor_names, capacities, seed
     )
-
     game.solve()
-    assert not game._check_for_unacceptable_matchings("students")
 
     student = game.students[0]
     project = Project(name="foo", capacity=0)
     student.matching = project
-    errors = game._check_for_unacceptable_matchings("students")
-    assert len(errors) == 1
-    assert student.name in errors[0]
-    assert project.name in errors[0]
-    assert str(student.prefs) in errors[0]
+
+    with pytest.raises(MatchingError) as error:
+        game.check_validity()
+        e = error.unacceptables[0]
+        assert student.name in e
+        assert project.name in e
+        assert str(student.prefs) in e
 
 
 @STUDENT_ALLOCATION
@@ -552,18 +552,18 @@ def test_check_for_unacceptable_matchings_projects(
     _, _, _, game = make_game(
         student_names, project_names, supervisor_names, capacities, seed
     )
-
     game.solve()
-    assert not game._check_for_unacceptable_matchings("projects")
 
     project = game.projects[0]
     student = Student(name="foo")
     project.matching.append(student)
-    errors = game._check_for_unacceptable_matchings("projects")
-    assert len(errors) == 1
-    assert project.name in errors[0]
-    assert student.name in errors[0]
-    assert str(project.prefs) in errors[0]
+
+    with pytest.raises(MatchingError) as error:
+        game.check_validity()
+        e = error.unacceptables[0]
+        assert project.name in errors[0]
+        assert student.name in errors[0]
+        assert str(project.prefs) in errors[0]
 
 
 @STUDENT_ALLOCATION
@@ -577,18 +577,18 @@ def test_check_for_unacceptable_matchings_supervisors(
     _, _, _, game = make_game(
         student_names, project_names, supervisor_names, capacities, seed
     )
-
     game.solve()
-    assert not game._check_for_unacceptable_matchings("supervisors")
 
     supervisor = game.supervisors[0]
     student = Student(name="foo")
     supervisor.matching.append(student)
-    errors = game._check_for_unacceptable_matchings("supervisors")
-    assert len(errors) == 1
-    assert supervisor.name in errors[0]
-    assert student.name in errors[0]
-    assert str(supervisor.prefs) in errors[0]
+
+    with pytest.raises(MatchingError) as error:
+        game.check_validity()
+        e = error.unacceptables[0]
+        assert supervisor.name in e
+        assert student.name in e
+        assert str(supervisor.prefs) in e
 
 
 @STUDENT_ALLOCATION
@@ -601,17 +601,17 @@ def test_check_for_oversubscribed_projects(
     _, _, _, game = make_game(
         student_names, project_names, supervisor_names, capacities, seed
     )
-
     game.solve()
-    assert not game._check_for_oversubscribed_players("projects")
 
     project = game.projects[0]
     project.matching = range(project.capacity + 1)
-    errors = game._check_for_oversubscribed_players("projects")
-    assert len(errors) == 1
-    assert project.name in errors[0]
-    assert str(project.matching) in errors[0]
-    assert str(project.capacity) in errors[0]
+
+    with pytest.raises(MatchingError) as error:
+        game.check_validity()
+        e = error.oversubscribeds[0]
+        assert project.name in e
+        assert str(project.matching) in e
+        assert str(project.capacity) in e
 
 
 @STUDENT_ALLOCATION
@@ -624,17 +624,17 @@ def test_check_for_oversubscribed_supervisors(
     _, _, _, game = make_game(
         student_names, project_names, supervisor_names, capacities, seed
     )
-
     game.solve()
-    assert not game._check_for_oversubscribed_players("supervisors")
 
     supervisor = game.supervisors[0]
     supervisor.matching = range(supervisor.capacity + 1)
-    errors = game._check_for_oversubscribed_players("supervisors")
-    assert len(errors) == 1
-    assert supervisor.name in errors[0]
-    assert str(supervisor.matching) in errors[0]
-    assert str(supervisor.capacity) in errors[0]
+
+    with pytest.raises(MatchingError) as error:
+        game.check_validity()
+        e = error.oversubscribeds[0]
+        assert supervisor.name in e
+        assert str(supervisor.matching) in e
+        assert str(supervisor.capacity) in e
 
 
 def test_check_stability():

--- a/tests/student_allocation/test_solver.py
+++ b/tests/student_allocation/test_solver.py
@@ -519,7 +519,7 @@ def test_check_validity(
 
 
 @STUDENT_ALLOCATION
-def test_check_for_unacceptable_matchings_students(
+def test_check_for_unacceptable_matches_students(
     student_names, project_names, supervisor_names, capacities, seed
 ):
     """ Test that StudentAllocation recognises a valid matching requires each
@@ -534,16 +534,16 @@ def test_check_for_unacceptable_matchings_students(
     project = Project(name="foo", capacity=0)
     student.matching = project
 
-    with pytest.raises(MatchingError) as error:
+    with pytest.raises(MatchingError) as e:
         game.check_validity()
-        e = error.unacceptables[0]
-        assert student.name in e
-        assert project.name in e
-        assert str(student.prefs) in e
+        error = e.unacceptable_matches[0]
+        assert error.startswith(student.name)
+        assert error.endswith(str(student.prefs))
+        assert project.name in error
 
 
 @STUDENT_ALLOCATION
-def test_check_for_unacceptable_matchings_projects(
+def test_check_for_unacceptable_matches_projects(
     student_names, project_names, supervisor_names, capacities, seed
 ):
     """ Test that StudentAllocation recognises a valid matching requires each
@@ -558,16 +558,16 @@ def test_check_for_unacceptable_matchings_projects(
     student = Student(name="foo")
     project.matching.append(student)
 
-    with pytest.raises(MatchingError) as error:
+    with pytest.raises(MatchingError) as e:
         game.check_validity()
-        e = error.unacceptables[0]
-        assert project.name in errors[0]
-        assert student.name in errors[0]
-        assert str(project.prefs) in errors[0]
+        error = e.unacceptable_matches[0]
+        assert error.startswith(project.name)
+        assert error.endswith(str(project.prefs))
+        assert str(student.name) in error
 
 
 @STUDENT_ALLOCATION
-def test_check_for_unacceptable_matchings_supervisors(
+def test_check_for_unacceptable_matches_supervisors(
     student_names, project_names, supervisor_names, capacities, seed
 ):
     """ Test that StudentAllocation recognises a valid matching requires each
@@ -583,12 +583,12 @@ def test_check_for_unacceptable_matchings_supervisors(
     student = Student(name="foo")
     supervisor.matching.append(student)
 
-    with pytest.raises(MatchingError) as error:
+    with pytest.raises(MatchingError) as e:
         game.check_validity()
-        e = error.unacceptables[0]
-        assert supervisor.name in e
-        assert student.name in e
-        assert str(supervisor.prefs) in e
+        error = e.unacceptable_matches[0]
+        assert error.startswith(supervisor.name)
+        assert error.endswith(str(supervisor.prefs))
+        assert student.name in error
 
 
 @STUDENT_ALLOCATION
@@ -606,12 +606,12 @@ def test_check_for_oversubscribed_projects(
     project = game.projects[0]
     project.matching = range(project.capacity + 1)
 
-    with pytest.raises(MatchingError) as error:
+    with pytest.raises(MatchingError) as e:
         game.check_validity()
-        e = error.oversubscribeds[0]
-        assert project.name in e
+        error = e.oversubscribed_players[0]
+        assert error.startswith(project.name)
+        assert error.endswith(str(project.capacity))
         assert str(project.matching) in e
-        assert str(project.capacity) in e
 
 
 @STUDENT_ALLOCATION
@@ -629,12 +629,12 @@ def test_check_for_oversubscribed_supervisors(
     supervisor = game.supervisors[0]
     supervisor.matching = range(supervisor.capacity + 1)
 
-    with pytest.raises(MatchingError) as error:
+    with pytest.raises(MatchingError) as e:
         game.check_validity()
-        e = error.oversubscribeds[0]
-        assert supervisor.name in e
+        error = e.oversubscribed_players[0]
+        assert error.startswith(supervisor.name)
+        assert error.endswith(str(supervisor.capacity))
         assert str(supervisor.matching) in e
-        assert str(supervisor.capacity) in e
 
 
 def test_check_stability():


### PR DESCRIPTION
Rather than have duplicate and largely equivalent methods in each game, this PR generalises the matching validation process.

Now each base player class (`Player` and `Hospital`) has their own methods for checking their match(es). These methods make use of the `MatchingError` exception -- which has also been generalised.

Likewise, each base game (`StableRoommates`, `StableMarriage`, `HospitalResident`) has its own methods for checking their players.