### PR TITLE
Fix ipython version to avoid warnings.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1.1.1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -31,6 +31,7 @@ jobs:
         python -m pip install -q --no-cache-dir sphinx sphinx_rtd_theme
         python -m pip install -q --no-cache-dir nbval sphinxcontrib-bibtex
         python -m pip install -q --no-cache-dir matplotlib pandas PyYAML
+        python -m pip install -q --no-cache-dir ipython==7.10
         python -m pip list
     - name: Lint with Black
       if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,7 +5,7 @@ dependencies:
     - matplotlib>=3
     - numpy>=1.16
     - pandas>=0.24
-    - ipython>=7.6
+    - ipython=7.10
     - python>=3.6
     - pip>=19
     - sphinx=2.4.0


### PR DESCRIPTION
There were some weird warnings coming from an internal
`ipython`/`ipykernel` API, causing `pytest-nbval` to fail its tests. So,
downgrading `ipython` to 7.10 until that is fixed.

Details are available under https://github.com/ipython/ipykernel/issues/540.