### PR TITLE
Add `NoStableMatchingWarning` for SR

### DIFF
--- a/src/matching/algorithms/stable_roommates.py
+++ b/src/matching/algorithms/stable_roommates.py
@@ -1,4 +1,7 @@
 """ Functions for the SR algorithm. """
+import warnings
+
+from matching.exceptions import NoStableMatchingWarning
 
 from .util import _delete_pair
 
@@ -93,6 +96,12 @@ def second_phase(players):
             _delete_pair(player, other)
 
         if any(p.prefs == [] for p in players):
+            warnings.warn(
+                NoStableMatchingWarning(
+                    "The following players have emptied their preference list: "
+                    f"{[p for p in players if not p.prefs]}"
+                )
+            )
             break
 
         try:
@@ -125,6 +134,16 @@ def stable_roommates(players):
     """
 
     players = first_phase(players)
+
+    if any(p.prefs == [] for p in players):
+        warnings.warn(
+            NoStableMatchingWarning(
+                "The following players have been rejected by all others, "
+                "emptying their preference list: "
+                f"{[p for p in players if not p.prefs]}"
+            )
+        )
+
     if any(len(p.prefs) > 1 for p in players):
         players = second_phase(players)
 

--- a/src/matching/exceptions.py
+++ b/src/matching/exceptions.py
@@ -13,6 +13,10 @@ class MatchingError(Exception):
         super().__init__(self.message)
 
 
+class NoStableMatchingWarning(UserWarning):
+    """ A warning for when a game does not have a complete stable matching. """
+
+
 class PreferencesChangedWarning(UserWarning):
     """ A warning for when the preferences of a player are invalid. """
 

--- a/tests/stable_roommates/test_examples.py
+++ b/tests/stable_roommates/test_examples.py
@@ -1,10 +1,16 @@
 """ A collection of example tests. """
+import warnings
+
+from hypothesis import given
+from hypothesis.strategies import permutations
 
 from matching import Player
 from matching.algorithms import stable_roommates
+from matching.exceptions import NoStableMatchingWarning
+from matching.games.stable_roommates import _make_players
 
 
-def test_original_paper():
+def test_original_paper_stable():
     """Verify that the matching found is consistent with the example in the
     original paper."""
 
@@ -20,6 +26,64 @@ def test_original_paper():
 
     matching = stable_roommates(players)
     assert matching == {a: f, b: c, c: b, d: e, e: d, f: a}
+
+
+@given(last_player_prefs=permutations([1, 2, 3]))
+def test_gale_shapley_no_stable_matching(last_player_prefs):
+    """Verify that the example from [GS62] throws up a warning that there is no
+    stable matching."""
+
+    preferences = {
+        1: [2, 3, 4],
+        2: [3, 1, 4],
+        3: [1, 2, 4],
+        4: last_player_prefs,
+    }
+
+    players = _make_players(preferences)
+
+    with warnings.catch_warnings(record=True) as w:
+        stable_roommates(players)
+
+    message = w[-1].message
+    assert isinstance(message, NoStableMatchingWarning)
+    assert "4" in str(message)
+
+
+def test_large_example_from_book():
+    """Verify that the matching found is consistent with the example of size ten
+    in [GI89] (Section 4.2.3)."""
+
+    preferences = {
+        1: [8, 2, 9, 3, 6, 4, 5, 7, 10],
+        2: [4, 3, 8, 9, 5, 1, 10, 6, 7],
+        3: [5, 6, 8, 2, 1, 7, 10, 4, 9],
+        4: [10, 7, 9, 3, 1, 6, 2, 5, 8],
+        5: [7, 4, 10, 8, 2, 6, 3, 1, 9],
+        6: [2, 8, 7, 3, 4, 10, 1, 5, 9],
+        7: [2, 1, 8, 3, 5, 10, 4, 6, 9],
+        8: [10, 4, 2, 5, 6, 7, 1, 3, 9],
+        9: [6, 7, 2, 5, 10, 3, 4, 8, 1],
+        10: [3, 1, 6, 5, 2, 9, 8, 4, 7],
+    }
+
+    players = _make_players(preferences)
+    one, two, three, four, five, six, seven, eight, nine, ten = players
+
+    matching = stable_roommates(players)
+
+    assert matching == {
+        one: seven,
+        two: eight,
+        three: six,
+        four: nine,
+        five: ten,
+        six: three,
+        seven: one,
+        eight: two,
+        nine: four,
+        ten: five,
+    }
 
 
 def test_example_in_issue_64():


### PR DESCRIPTION
Sometimes, instances of SR have no stable matching. This occurs when any player has their preference list emptied; by being rejected by everyone in the first phase, or by being paired up with all of their remaining preferences in all-or-nothing cycles during the second phase.

This warning `matching.exceptions.NoStableMatchingWarning` rings when either of these things happen, but does not stop the algorithm from continuing until its natural termination.